### PR TITLE
Implement trapezoidal rule errors for TI

### DIFF
--- a/src/alchemlyb/estimators/ti_.py
+++ b/src/alchemlyb/estimators/ti_.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 from sklearn.base import BaseEstimator
 
+
 class TI(BaseEstimator):
     """Thermodynamic integration (TI).
 
@@ -17,50 +18,14 @@ class TI(BaseEstimator):
 
     delta_f_ : DataFrame
         The estimated dimensionless free energy difference between each state.
+    d_delta_f_ : DataFrame
+        The estimated statistical uncertainty (one standard deviation) in 
+        dimensionless free energy differences.
 
     """
 
     def __init__(self, verbose=False):
         self.verbose = verbose
-
-    def _partial_sum_error(self, i, dl, dHdl_var):
-        """
-        Calculate the error of the partial sums in the trapezoidal rule.
-
-        Parameters
-        ----------
-        i : int
-            the ith partial sum (starting at 0)
-
-        dl : array-like
-            The delta lambdas between states
-
-        dHdl_var : array-like
-            The variance of each lambda state
-        """
-
-        return 0.25 * (dl[i]**2) * (dHdl_var[i] + dHdl_var[i+1])
-
-    def _trapezoidal_error(self, i, j, dl, dHdl_var):
-        """Calculate the error of the trapezoidal rule integral approximation
-        betweeen state i and state j
-        
-        Parameters
-        ----------
-        i : int
-            index of state i (starting at 0)
-
-        j : int
-            index of state j (starting at 0)
-
-        dl : array-like
-            The delta lambdas between states
-
-        dHdl_var : array-like
-            The variance of each lambda state
-        """
-
-        return np.sum([self._partial_sum_error(x, dl, dHdl_var) for x in range(i,j+1)])
 
     def fit(self, dHdl):
         """
@@ -79,39 +44,40 @@ class TI(BaseEstimator):
         # and adjacent states are next to each other
         dHdl = dHdl.sort_index(level=dHdl.index.names[1:])
 
-        # obtain the mean value for each state
+        # obtain the mean and variance for each state
+        # variance calculation assumes no correlation
         means = dHdl.mean(level=dHdl.index.names[1:])
-        variance = dHdl.std(level=dHdl.index.names[1:]).values**2
+        variances = dHdl.var(level=dHdl.index.names[1:])
         
         # obtain vector of delta lambdas between each state
         dl = means.reset_index()[means.index.names[:]].diff().iloc[1:].values
 
         # apply trapezoid rule to obtain DF between each adjacent state
         deltas = (dl * (means.iloc[:-1].values + means.iloc[1:].values)/2).sum(axis=1)
+        d_deltas = (dl**2 * (variances.iloc[:-1].values + variances.iloc[1:].values)/4).sum(axis=1)
 
         # build matrix of deltas between each state
         adelta = np.zeros((len(deltas)+1, len(deltas)+1))
-
-        # build matrix of delta errors between each state
-        adelta_error = np.zeros_like(adelta)
+        ad_delta = np.zeros_like(adelta)
 
         for j in range(len(deltas)):
             out = []
-            out_error = []
+            dout = []
             for i in range(len(deltas) - j):
                 out.append(deltas[i] + deltas[i+1:i+j+1].sum())
-                out_error.append(self._trapezoidal_error(i, j, dl, variance))
+                dout.append(d_deltas[i] + d_deltas[i+1:i+j+1].sum())
 
             adelta += np.diagflat(np.array(out), k=j+1)
-            adelta_error += np.diagflat(np.array(out_error), k=j+1)
+            ad_delta += np.diagflat(np.array(dout), k=j+1)
 
         # yield standard delta_f_ free energies between each state
         self.delta_f_ = pd.DataFrame(adelta - adelta.T,
                                      columns=means.index.values,
                                      index=means.index.values)
-        # yield delta_f_error_ free energy errors between each state
-        self.delta_f_error_ = pd.DataFrame(adelta_error + adelta_error.T,
-                                           columns=means.index.values,
-                                           index=means.index.values)
+
+        # yield standard deviation d_delta_f_ between each state
+        self.d_delta_f_ = pd.DataFrame(np.sqrt(ad_delta + ad_delta.T),
+                                       columns=variances.index.values,
+                                       index=variances.index.values)
 
         return self

--- a/src/alchemlyb/estimators/ti_.py
+++ b/src/alchemlyb/estimators/ti_.py
@@ -44,10 +44,11 @@ class TI(BaseEstimator):
         # and adjacent states are next to each other
         dHdl = dHdl.sort_index(level=dHdl.index.names[1:])
 
-        # obtain the mean and variance for each state
-        # variance calculation assumes no correlation
+        # obtain the mean and variance of the mean for each state
+        # variance calculation assumes no correlation between points
+        # used to calculate mean
         means = dHdl.mean(level=dHdl.index.names[1:])
-        variances = dHdl.var(level=dHdl.index.names[1:])
+        variances = np.square(dHdl.sem(level=dHdl.index.names[1:]))
         
         # obtain vector of delta lambdas between each state
         dl = means.reset_index()[means.index.names[:]].diff().iloc[1:].values

--- a/src/alchemlyb/estimators/ti_.py
+++ b/src/alchemlyb/estimators/ti_.py
@@ -1,9 +1,7 @@
 import numpy as np
 import pandas as pd
-from scipy.integrate import simps
 
 from sklearn.base import BaseEstimator
-
 
 class TI(BaseEstimator):
     """Thermodynamic integration (TI).
@@ -25,6 +23,44 @@ class TI(BaseEstimator):
     def __init__(self, verbose=False):
         self.verbose = verbose
 
+    def _partial_sum_error(self, i, dl, dHdl_var):
+        """
+        Calculate the error of the partial sums in the trapezoidal rule.
+
+        Parameters
+        ----------
+        i : int
+            the ith partial sum (starting at 0)
+
+        dl : array-like
+            The delta lambdas between states
+
+        dHdl_var : array-like
+            The variance of each lambda state
+        """
+
+        return 0.25 * (dl[i]**2) * (dHdl_var[i] * dHdl_var[i+1])
+
+    def _trapezoidal_error(self, i, j, dl, dHdl_var):
+        """Calculate the error of the trapezoidal rule integral approximation
+        betweeen state i and state j
+        
+        Parameters
+        ----------
+        i : int
+            index of state i (starting at 0)
+
+        j : int
+            index of state j (starting at 0)
+
+        dl : array-like
+            The delta lambdas between states
+
+        dHdl_var : array-like
+            The variance of each lambda state
+        """
+
+        return np.sum([self._partial_sum_error(x, dl, dHdl_var) for x in range(i,j+1)])
 
     def fit(self, dHdl):
         """
@@ -45,6 +81,7 @@ class TI(BaseEstimator):
 
         # obtain the mean value for each state
         means = dHdl.mean(level=dHdl.index.names[1:])
+        variance = dHdl.std(level=dHdl.index.names[1:])**2
         
         # obtain vector of delta lambdas between each state
         dl = means.reset_index()[means.index.names[:]].diff().iloc[1:].values
@@ -55,19 +92,26 @@ class TI(BaseEstimator):
         # build matrix of deltas between each state
         adelta = np.zeros((len(deltas)+1, len(deltas)+1))
 
+        # build matrix of delta errors between each state
+        adelta_error = np.zeros_like(adelta)
+
         for j in range(len(deltas)):
             out = []
+            out_error = []
             for i in range(len(deltas) - j):
                 out.append(deltas[i] + deltas[i+1:i+j+1].sum())
+                out_error.append(self._trapezoidal_error(i, j, dl, variance))
 
             adelta += np.diagflat(np.array(out), k=j+1)
+            adelta_error += np.diagflat(np.array(out_error), k=j+1)
 
         # yield standard delta_f_ free energies between each state
         self.delta_f_ = pd.DataFrame(adelta - adelta.T,
                                      columns=means.index.values,
                                      index=means.index.values)
+        # yield delta_f_error_ free energy errors between each state
+        self.delta_f_error_ = pd.DataFrame(adelta_error + adelta_error.T,
+                                           columns=means.index.values,
+                                           index=means.index.values)
 
         return self
-        
-
-

--- a/src/alchemlyb/estimators/ti_.py
+++ b/src/alchemlyb/estimators/ti_.py
@@ -39,7 +39,7 @@ class TI(BaseEstimator):
             The variance of each lambda state
         """
 
-        return 0.25 * (dl[i]**2) * (dHdl_var[i] * dHdl_var[i+1])
+        return 0.25 * (dl[i]**2) * (dHdl_var[i] + dHdl_var[i+1])
 
     def _trapezoidal_error(self, i, j, dl, dHdl_var):
         """Calculate the error of the trapezoidal rule integral approximation
@@ -81,7 +81,7 @@ class TI(BaseEstimator):
 
         # obtain the mean value for each state
         means = dHdl.mean(level=dHdl.index.names[1:])
-        variance = dHdl.std(level=dHdl.index.names[1:])**2
+        variance = dHdl.std(level=dHdl.index.names[1:]).values**2
         
         # obtain vector of delta lambdas between each state
         dl = means.reset_index()[means.index.names[:]].diff().iloc[1:].values


### PR DESCRIPTION
Error calculations are not currently implemented in the TI estimator.
- [ ] Errors from correlated data in the XVGs 
- [x] Errors from the trapezoidal rule integral approximation