### PR TITLE
Added python 3.6 to travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 python:
    - "2.7"
    - "3.5"
+   - "3.6"
 
 branches:
     only:


### PR DESCRIPTION
I'm getting failures of some of the subsamplers on my local machine
under Python 3.6. It's time we add this to the Travis CI checks to see
if this is the culprit, but also to test against latest Python.