### PR TITLE
amber mbar parser

### DIFF
--- a/docs/parsing/alchemlyb.parsing.amber.rst
+++ b/docs/parsing/alchemlyb.parsing.amber.rst
@@ -17,4 +17,4 @@ API Reference
 This submodule includes these parsing functions:
 
 .. autofunction:: alchemlyb.parsing.amber.extract_dHdl
-
+.. autofunction:: alchemlyb.parsing.amber.extract_u_nk

--- a/src/alchemlyb/tests/parsing/test_amber.py
+++ b/src/alchemlyb/tests/parsing/test_amber.py
@@ -6,10 +6,13 @@ import pytest
 from six.moves import zip
 
 from alchemlyb.parsing.amber import extract_dHdl
+from alchemlyb.parsing.amber import extract_u_nk
 from alchemlyb.parsing.amber import file_validation
 from alchemlyb.parsing.amber import any_none
 from alchemtest.amber import load_simplesolvated
 from alchemtest.amber import load_invalidfiles
+from alchemtest.amber import load_bace_example
+from alchemtest.amber import load_bace_improper
 
 
 @pytest.fixture(scope="module",
@@ -19,9 +22,9 @@ def invalid_file(request):
 
 
 @pytest.mark.parametrize("filename",
-                          [filename
-                           for leg in load_simplesolvated()['data'].values()
-                           for filename in leg])
+                         [filename
+                          for leg in load_simplesolvated()['data'].values()
+                          for filename in leg])
 def test_dHdl(filename,
               names=('time', 'lambdas'),
               shape=(500, 1)):
@@ -31,13 +34,44 @@ def test_dHdl(filename,
     assert dHdl.index.names == names
     assert dHdl.shape == shape
 
+
+@pytest.mark.parametrize("mbar_filename",
+                         [mbar_filename
+                          for leg in load_bace_example()['data']['complex'].values()
+                          for mbar_filename in leg])
+def test_u_nk(mbar_filename,
+              names=('time', 'lambdas')):
+    """Test the u_nk has the correct form when extracted from files"""
+    u_nk = extract_u_nk(mbar_filename)
+
+    assert u_nk.index.names == names
+
+
+@pytest.mark.parametrize("improper_filename",
+                         [improper_filename
+                          for leg in load_bace_improper()['data'].values()
+                          for improper_filename in leg])
+def test_u_nk_improper(improper_filename,
+                       names=('time', 'lambdas')):
+    """Test the u_nk has the correct form when extracted from files"""
+    try:
+        u_nk = extract_u_nk(improper_filename)
+
+        assert u_nk.index.names == names
+
+    except:
+        assert '0.5626' in improper_filename
+
+
 def test_invalidfiles(invalid_file):
     """Test the file validation function to ensure the function returning False if the file is invalid
     """
     assert file_validation(invalid_file) == False
 
+
 def test_dHdl_invalidfiles(invalid_file):
     assert extract_dHdl(invalid_file) is None
+
 
 def test_any_none():
     """Test the any None function to ensure if the None value will be caught"""


### PR DESCRIPTION
Fixes #42 

This pull request adds support for amber mbar parsing for amber .out  files by using the [extract_u_nk](https://github.com/alchemistry/alchemlyb/blob/amber-mbar-parse/src/alchemlyb/parsing/amber.py#L250) function, which I wrote to primarily mimic the output format of the [extract_u_nk](https://github.com/alchemistry/alchemlyb/blob/amber-mbar-parse/src/alchemlyb/parsing/gmx.py#L15) gromacs function. 

A [test_u_nk](https://github.com/alchemistry/alchemlyb/blob/amber-mbar-parse/src/alchemlyb/tests/parsing/test_amber.py#L35) function was also added to [test_amber.py](https://github.com/alchemistry/alchemlyb/blob/amber-mbar-parse/src/alchemlyb/tests/parsing/test_amber.py). I am now working on adding a minimal test example to [alchemtest](https://github.com/alchemistry/alchemtest).