### PR TITLE
Add pV and U to reduced potential when they are given

### DIFF
--- a/src/alchemlyb/parsing/gmx.py
+++ b/src/alchemlyb/parsing/gmx.py
@@ -31,7 +31,7 @@ def extract_u_nk(xvg, T):
 
     h_col_match = r"\xD\f{}H \xl\f{}"
     pv_col_match = 'pV'
-    u_col_match = 'Total Energy'
+    u_col_match = ['Total Energy', 'Potential Energy']
     beta = 1/(k_b * T)
 
     state, lambdas, statevec = _extract_state(xvg)
@@ -54,8 +54,8 @@ def extract_u_nk(xvg, T):
     if pv_cols:
         pv = df[pv_cols[0]]
 
-    # gromacs also gives us total energy U directly; need this for reduced potential
-    u_cols = [col for col in df.columns if (u_col_match in col)]
+    # gromacs also gives us total/potential energy U directly; need this for reduced potential
+    u_cols = [col for col in df.columns if any(single_u_col_match in col for single_u_col_match in u_col_match)]
     u = None
     if u_cols:
         u = df[u_cols[0]]

--- a/src/alchemlyb/tests/parsing/test_gmx.py
+++ b/src/alchemlyb/tests/parsing/test_gmx.py
@@ -5,6 +5,9 @@
 from alchemlyb.parsing.gmx import extract_dHdl, extract_u_nk
 from alchemtest.gmx import load_benzene
 from alchemtest.gmx import load_expanded_ensemble_case_1, load_expanded_ensemble_case_2, load_expanded_ensemble_case_3
+from alchemtest.gmx import load_water_particle_with_total_energy
+from alchemtest.gmx import load_water_particle_with_potential_energy
+from alchemtest.gmx import load_water_particle_without_energy
 
 
 def test_dHdl():
@@ -103,3 +106,65 @@ def test_dHdl_case3():
 
             assert dHdl.index.names == ['time', 'fep-lambda', 'coul-lambda', 'vdw-lambda', 'restraint-lambda']
             assert dHdl.shape == (2500, 4)
+
+def test_u_nk_with_total_energy():
+    """Test that the reduced potential is calculated correctly when the total energy is given.
+
+    """
+
+    # Load dataset
+    dataset = load_water_particle_with_total_energy()
+
+    # Check if the sum of values on the diagonal has the correct value
+    assert _diag_sum(dataset) == 47611377946.58586
+
+    # Check one specific value in the dataframe
+    assert float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]) == -11250.643602869592
+
+def test_u_nk_with_potential_energy():
+    """Test that the reduced potential is calculated correctly when the potential energy is given.
+
+    """
+
+    # Load dataset
+    dataset = load_water_particle_with_potential_energy()
+
+    # Check if the sum of values on the diagonal has the correct value
+    assert _diag_sum(dataset) == 16674041445589.646
+
+    # Check one specific value in the dataframe
+    assert float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]) == -15659.655560881085
+
+
+def test_u_nk_without_energy():
+    """Test that the reduced potential is calculated correctly when no energy is given.
+
+    """
+
+    # Load dataset
+    dataset = load_water_particle_without_energy()
+
+    # Check if the sum of values on the diagonal has the correct value
+    assert _diag_sum(dataset) == 20572988148877.555
+
+    # Check one specific value in the dataframe
+    assert float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]) == 18.134225023007403
+
+
+def _diag_sum(dataset):
+    """Calculate the sum of diagonal elements (i, i)
+
+    """
+
+    # Initialize the sum variable
+    ds = 0.0
+
+    for leg in dataset['data']:
+        for filename in dataset['data'][leg]:
+            u_nk = extract_u_nk(filename, T=300)
+
+            # Calculate the sum of diagonal elements:
+            for i in range(len(dataset['data'][leg])):
+                ds += u_nk.iloc[i][i]
+
+    return ds

--- a/src/alchemlyb/tests/parsing/test_gmx.py
+++ b/src/alchemlyb/tests/parsing/test_gmx.py
@@ -117,10 +117,14 @@ def test_u_nk_with_total_energy():
     dataset = load_water_particle_with_total_energy()
 
     # Check if the sum of values on the diagonal has the correct value
-    assert_almost_equal(_diag_sum(dataset), 47611377946.58586)
+    assert_almost_equal(_diag_sum(dataset), 47611377946.58586, decimal=6)
 
     # Check one specific value in the dataframe
-    assert_almost_equal(float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]), -11250.643602869592)
+    assert_almost_equal(
+        float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]),
+        -11250.643602869592,
+        decimal=6
+    )
 
 def test_u_nk_with_potential_energy():
     """Test that the reduced potential is calculated correctly when the potential energy is given.
@@ -131,10 +135,14 @@ def test_u_nk_with_potential_energy():
     dataset = load_water_particle_with_potential_energy()
 
     # Check if the sum of values on the diagonal has the correct value
-    assert_almost_equal(_diag_sum(dataset), 16674041445589.646)
+    assert_almost_equal(_diag_sum(dataset), 16674041445589.646, decimal=6)
 
     # Check one specific value in the dataframe
-    assert_almost_equal(float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]), -15659.655560881085)
+    assert_almost_equal(
+        float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]),
+        -15659.655560881085,
+        decimal=6
+    )
 
 
 def test_u_nk_without_energy():
@@ -146,10 +154,14 @@ def test_u_nk_without_energy():
     dataset = load_water_particle_without_energy()
 
     # Check if the sum of values on the diagonal has the correct value
-    assert_almost_equal(_diag_sum(dataset), 20572988148877.555)
+    assert_almost_equal(_diag_sum(dataset), 20572988148877.555, decimal=6)
 
     # Check one specific value in the dataframe
-    assert_almost_equal(float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]), 18.134225023007403)
+    assert_almost_equal(
+        float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]),
+        18.134225023007403,
+        decimal=6
+    )
 
 
 def _diag_sum(dataset):

--- a/src/alchemlyb/tests/parsing/test_gmx.py
+++ b/src/alchemlyb/tests/parsing/test_gmx.py
@@ -121,7 +121,7 @@ def test_u_nk_with_total_energy():
 
     # Check one specific value in the dataframe
     assert_almost_equal(
-        float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]),
+        extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0],
         -11211.578357345974,
         decimal=6
     )
@@ -139,7 +139,7 @@ def test_u_nk_with_potential_energy():
 
     # Check one specific value in the dataframe
     assert_almost_equal(
-        float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]),
+        extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0],
         -15656.558227621246,
         decimal=6
     )
@@ -158,7 +158,7 @@ def test_u_nk_without_energy():
 
     # Check one specific value in the dataframe
     assert_almost_equal(
-        float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]),
+        extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0],
         0.0,
         decimal=6
     )

--- a/src/alchemlyb/tests/parsing/test_gmx.py
+++ b/src/alchemlyb/tests/parsing/test_gmx.py
@@ -8,6 +8,7 @@ from alchemtest.gmx import load_expanded_ensemble_case_1, load_expanded_ensemble
 from alchemtest.gmx import load_water_particle_with_total_energy
 from alchemtest.gmx import load_water_particle_with_potential_energy
 from alchemtest.gmx import load_water_particle_without_energy
+from numpy.testing import assert_almost_equal
 
 
 def test_dHdl():
@@ -116,10 +117,10 @@ def test_u_nk_with_total_energy():
     dataset = load_water_particle_with_total_energy()
 
     # Check if the sum of values on the diagonal has the correct value
-    assert _diag_sum(dataset) == 47611377946.58586
+    assert_almost_equal(_diag_sum(dataset), 47611377946.58586)
 
     # Check one specific value in the dataframe
-    assert float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]) == -11250.643602869592
+    assert_almost_equal(float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]), -11250.643602869592)
 
 def test_u_nk_with_potential_energy():
     """Test that the reduced potential is calculated correctly when the potential energy is given.
@@ -130,10 +131,10 @@ def test_u_nk_with_potential_energy():
     dataset = load_water_particle_with_potential_energy()
 
     # Check if the sum of values on the diagonal has the correct value
-    assert _diag_sum(dataset) == 16674041445589.646
+    assert_almost_equal(_diag_sum(dataset), 16674041445589.646)
 
     # Check one specific value in the dataframe
-    assert float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]) == -15659.655560881085
+    assert_almost_equal(float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]), -15659.655560881085)
 
 
 def test_u_nk_without_energy():
@@ -145,10 +146,10 @@ def test_u_nk_without_energy():
     dataset = load_water_particle_without_energy()
 
     # Check if the sum of values on the diagonal has the correct value
-    assert _diag_sum(dataset) == 20572988148877.555
+    assert_almost_equal(_diag_sum(dataset), 20572988148877.555)
 
     # Check one specific value in the dataframe
-    assert float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]) == 18.134225023007403
+    assert_almost_equal(float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]), 18.134225023007403)
 
 
 def _diag_sum(dataset):

--- a/src/alchemlyb/tests/parsing/test_gmx.py
+++ b/src/alchemlyb/tests/parsing/test_gmx.py
@@ -117,7 +117,7 @@ def test_u_nk_with_total_energy():
     dataset = load_water_particle_with_total_energy()
 
     # Check if the sum of values on the diagonal has the correct value
-    assert_almost_equal(_diag_sum(dataset), 47611377946.58586, decimal=6)
+    assert_almost_equal(_diag_sum(dataset), 47611377946.58586, decimal=4)
 
     # Check one specific value in the dataframe
     assert_almost_equal(
@@ -135,7 +135,7 @@ def test_u_nk_with_potential_energy():
     dataset = load_water_particle_with_potential_energy()
 
     # Check if the sum of values on the diagonal has the correct value
-    assert_almost_equal(_diag_sum(dataset), 16674041445589.646, decimal=6)
+    assert_almost_equal(_diag_sum(dataset), 16674041445589.646, decimal=2)
 
     # Check one specific value in the dataframe
     assert_almost_equal(
@@ -154,7 +154,7 @@ def test_u_nk_without_energy():
     dataset = load_water_particle_without_energy()
 
     # Check if the sum of values on the diagonal has the correct value
-    assert_almost_equal(_diag_sum(dataset), 20572988148877.555, decimal=6)
+    assert_almost_equal(_diag_sum(dataset), 20572988148877.555, decimal=2)
 
     # Check one specific value in the dataframe
     assert_almost_equal(

--- a/src/alchemlyb/tests/parsing/test_gmx.py
+++ b/src/alchemlyb/tests/parsing/test_gmx.py
@@ -122,7 +122,7 @@ def test_u_nk_with_total_energy():
     # Check one specific value in the dataframe
     assert_almost_equal(
         float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]),
-        -11250.643602869592,
+        -11211.578357345974,
         decimal=6
     )
 
@@ -140,7 +140,7 @@ def test_u_nk_with_potential_energy():
     # Check one specific value in the dataframe
     assert_almost_equal(
         float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]),
-        -15659.655560881085,
+        -15656.558227621246,
         decimal=6
     )
 
@@ -159,7 +159,7 @@ def test_u_nk_without_energy():
     # Check one specific value in the dataframe
     assert_almost_equal(
         float(extract_u_nk(dataset['data']['AllStates'][0], T=300).iloc[0][0]),
-        18.134225023007403,
+        0.0,
         decimal=6
     )
 

--- a/src/alchemlyb/tests/test_preprocessing.py
+++ b/src/alchemlyb/tests/test_preprocessing.py
@@ -100,7 +100,7 @@ class TestStatisticalInefficiency(TestSlicing, CorrelatedPreprocessors):
                                  (True, gmx_benzene_dHdl(), 2001),  # 0.00:  g = 1.0559445620585415
                                  (True, gmx_benzene_u_nk(), 2001),  # 'fep': g = 1.0560203916559594
                                  (False, gmx_benzene_dHdl(), 3789),
-                                 (False, gmx_benzene_u_nk(), 3789),
+                                 (False, gmx_benzene_u_nk(), 3571),
                              ])
     def test_conservative(self, data, size, conservative):
         sliced = self.slicer(data, series=data.iloc[:, 0], conservative=conservative)


### PR DESCRIPTION
As explained in https://github.com/alchemistry/alchemlyb/issues/59 The current parser assumes U and pV to be given in the second respectively last column - which is not very robust.

With these changes the parser adds them to the potential differences only when they are given. 

Moreover I am interested if these changes pass the tests.