### PR TITLE
Set Travis CI to test against Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
-sudo: false
+sudo: required
+dist: xenial
 
 python:
    - "2.7"
    - "3.5"
    - "3.6"
+   - "3.7"
 
 branches:
     only:


### PR DESCRIPTION
Requires us to use `dist: xenial` (Ubuntu 16.04) to add this Python version to the test matrix.