### PR TITLE
Make amber parser compatible with python 3.7

### DIFF
--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -60,7 +60,10 @@ def _pre_gen(it, first):
         yield first
 
     while it:
-        yield next(it)
+        try:
+            yield next(it)
+        except StopIteration:
+            return
 
 
 class SectionParser(object):


### PR DESCRIPTION
As explained in https://github.com/alchemistry/alchemlyb/issues/66 the amber parser does not work in Python 3.7.

These changes should fix this.

See https://www.python.org/dev/peps/pep-0479/#sub-proposal-decorator-to-explicitly-request-current-behaviour