### PR TITLE
gmx parser (_extract_dataframe) using pd.read_csv for performance

### DIFF
--- a/src/alchemlyb/parsing/gmx.py
+++ b/src/alchemlyb/parsing/gmx.py
@@ -265,7 +265,8 @@ def _extract_dataframe(xvg, headers=None):
     cols = [xaxis] + names
     header_cnt = len(headers['_raw_lines'])
     df = pd.read_csv(xvg, sep=r"\s+", header=None, skiprows=header_cnt,
-            na_filter=True, memory_map=True, names=cols, dtype=np.float64)
+            na_filter=True, memory_map=True, names=cols, dtype=np.float64,
+            float_precision='high')
 
     # Dealing with duplicates
     # Pandas permits unique column names only, mangle_dupe_cols=False re-write

--- a/src/alchemlyb/parsing/gmx.py
+++ b/src/alchemlyb/parsing/gmx.py
@@ -335,11 +335,11 @@ def _get_headers(xvg):
     Given a xvg file containinig header lines like:
 
         ...
-       @    title "dH/d\xl\f{} and \xD\f{}H"
+       @    title "dH/d\\xl\\f{} and \\xD\\f{}H"
        @    xaxis  label "Time (ps)"
-       @    yaxis  label "dH/d\xl\f{} and \xD\f{}H (kJ/mol [\xl\f{}]\S-1\N)"
+       @    yaxis  label "dH/d\\xl\\f{} and \\xD\\f{}H (kJ/mol [\\xl\\f{}]\\S-1\\N)"
        @TYPE xy
-       @ subtitle "T = 310 (K) \xl\f{} state 38: (coul-lambda, vdw-lambda) = (0.9500, 0.0000)"
+       @ subtitle "T = 310 (K) \\xl\\f{} state 38: (coul-lambda, vdw-lambda) = (0.9500, 0.0000)"
        @ view 0.15, 0.15, 0.75, 0.85
        @ legend on
        @ legend box on
@@ -347,8 +347,8 @@ def _get_headers(xvg):
        @ legend 0.78, 0.8
        @ legend length 2
        @ s0 legend "Potential Energy (kJ/mol)"
-       @ s1 legend "dH/d\xl\f{} coul-lambda = 0.9500"
-       @ s2 legend "dH/d\xl\f{} vdw-lambda = 0.0000"
+       @ s1 legend "dH/d\\xl\\f{} coul-lambda = 0.9500"
+       @ s2 legend "dH/d\\xl\\f{} vdw-lambda = 0.0000"
        ...
 
     >>> _get_headers(xvg)

--- a/src/alchemlyb/parsing/util.py
+++ b/src/alchemlyb/parsing/util.py
@@ -15,7 +15,7 @@ except AttributeError:
     bz2_open = bz2.BZ2File
 else:
     def bz2_open(filename, mode):
-        mode += 't'
+        mode += 't' if mode in ['r','w','a','x'] else ''
         return bz2.open(filename, mode)
 
 # similar changes need to be made for gzip
@@ -28,7 +28,7 @@ except AttributeError:
     gzip_open = gzip.open
 else:
     def gzip_open(filename, mode):
-        mode += 't'
+        mode += 't' if mode in ['r','w','a','x'] else ''
         return gzip.open(filename, mode)
 
 


### PR DESCRIPTION
pd.read_csv() shows the same behavior building pandas Dataframe with better performance. Parsing header lines remain the same but with `bytes` reading, instead of `text` mode.