### PR TITLE
Removed redundant duplicate removal from gmx u_nk parser

### DIFF
--- a/src/alchemlyb/parsing/gmx.py
+++ b/src/alchemlyb/parsing/gmx.py
@@ -41,9 +41,6 @@ def extract_u_nk(xvg, T):
     # extract a DataFrame from XVG data
     df = _extract_dataframe(xvg)
 
-    # drop duplicate columns if we (stupidly) have them
-    df = df.iloc[:, ~df.columns.duplicated()]
-
     times = df[df.columns[0]]
 
     # want to grab only dH columns


### PR DESCRIPTION
This is follow-up work from #86. We don't want redundancy in duplicate removal here if we don't expect it to be necessary, as this can result in silently dropping things unintentionally or make issues harder to debug.