### PR TITLE
Changes in light of upstream pymbar 3.0.5

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,22 @@ The rules for this file:
 
 ------------------------------------------------------------------------------
 
+
+01/14/2020 dotsdl
+
+* 0.3.1
+
+Enhancements
+
+Deprecations
+
+Fixes
+  - added explicit `return_theta=True` for call to pymbar.MBAR.getFreeEnergyDifferences,
+    as this was happening prior to changes in `pymbar` without the explicit call
+
+Changes
+
+
 08/05/2019 dotsdl, orbeckst, shuail, trje3733, brycestx, harlor, vtlim, lee212
 
   * 0.3.0

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(name='alchemlyb',
       license='BSD',
       long_description=open('README.rst').read(),
       tests_require = ['pytest', 'alchemtest'],
-      install_requires=['numpy', 'pandas>=0.23.0', 'pymbar', 'scipy', 'scikit-learn']
+      install_requires=['numpy', 'pandas>=0.23.0', 'pymbar>=3.0.5', 'scipy', 'scikit-learn']
       )

--- a/src/alchemlyb/estimators/mbar_.py
+++ b/src/alchemlyb/estimators/mbar_.py
@@ -4,8 +4,6 @@ import pandas as pd
 from sklearn.base import BaseEstimator
 
 from pymbar import MBAR as MBAR_
-from pymbar.mbar import DEFAULT_SOLVER_PROTOCOL
-from pymbar.mbar import DEFAULT_SUBSAMPLING_PROTOCOL
 
 
 class MBAR(BaseEstimator):
@@ -55,7 +53,7 @@ class MBAR(BaseEstimator):
         self.maximum_iterations = maximum_iterations
         self.relative_tolerance = relative_tolerance
         self.initial_f_k = initial_f_k
-        self.method = (dict(method=method), )
+        self.method = [dict(method=method)]
         self.verbose = verbose
 
         # handle for pymbar.MBAR object
@@ -89,7 +87,7 @@ class MBAR(BaseEstimator):
         self.states_ = u_nk.columns.values.tolist()
 
         # set attributes
-        out = self._mbar.getFreeEnergyDifferences()
+        out = self._mbar.getFreeEnergyDifferences(return_theta=True)
         attrs = [pd.DataFrame(i,
                               columns=self.states_,
                               index=self.states_) for i in out]


### PR DESCRIPTION
We need an explicit `return_theta=True` call now, as before this was implicitly working.

Also switched to using a list for alchemlyb.estimators.MBAR.method, as this is in line with the stated docs for inputs to pymbar.MBAR (we were using a tuple).

We have set the install requirements in setupy.py to now have `pymbar==3.0.5` to ensure users are staying up to the latest version, as we intend to track pymbar's development carefully.