### PR TITLE
WIP: bootstrapping submodule, parameter for estimators

### DIFF
--- a/src/alchemlyb/preprocessing/bootstrapping.py
+++ b/src/alchemlyb/preprocessing/bootstrapping.py
@@ -2,22 +2,31 @@
 
 """
 import numpy as np
+import pandas as pd
 
-def bootstrap(df):
+
+def bootstrap(df, random_state=None):
     """Bootstrap sample a DataFrame to produce a new DataFrame.
 
     Values are sampled from `df` on a per-lambda-index basis.
+    Order of samples, or blocks of samples, are not preserved.
 
     Parameters
     ----------
     df : DataFrame
         DataFrame to bootstrap sample from.
+    random_state : int, optional
+        Integer between 0 and 2**32 -1 inclusive; fed to `numpy.random.seed`.
+        Running this function on the same data with a specific random seed will
+        produce the same result each time.
 
     Returns
     -------
     DataFrame
         DataFrame with the same shape as `df`, bootstrapped from the values of `df`.
     """
+    np.random.seed(random_state)
+
     df = df.copy()
     lambda_inds = [i for i in df.index.names if not i == 'time']
     

--- a/src/alchemlyb/preprocessing/bootstrapping.py
+++ b/src/alchemlyb/preprocessing/bootstrapping.py
@@ -1,0 +1,50 @@
+"""Functions for bootstrapping from datasets.
+
+"""
+import numpy as np
+
+def bootstrap(df):
+    """Bootstrap sample a DataFrame to produce a new DataFrame.
+
+    Values are sampled from `df` on a per-lambda-index basis.
+
+    Parameters
+    ----------
+    df : DataFrame
+        DataFrame to bootstrap sample from.
+
+    Returns
+    -------
+    DataFrame
+        DataFrame with the same shape as `df`, bootstrapped from the values of `df`.
+    """
+    df = df.copy()
+    lambda_inds = [i for i in df.index.names if not i == 'time']
+    
+    res = list()
+    for name, group in df.groupby(level=lambda_inds):
+        res.append(_bootstrap_samples(group))
+        
+    return pd.concat(res)
+    
+
+def _bootstrap_samples(df):
+    indices = np.random.choice(len(df), size=len(df))
+    return df.iloc[indices]
+
+
+def block_bootstrap(df, block_size=None, correlation_method=None):
+    """Block bootstrap a DataFrame from a DataFrame.
+
+    Parameters
+    ----------
+    df : DataFrame
+        DataFrame to block bootstrap sample from.
+
+    Returns
+    -------
+    DataFrame
+        DataFrame with the same shape as `df`, block bootstrapped from the values of `df`.
+    """
+    pass
+


### PR DESCRIPTION
This PR addresses #80.

We have added an `alchemlyb.preprocessing.bootstrapping` submodule. The functions exposed by this module should work on both `dHdl` and `u_nk` standard forms, with a similar usage feel to the `alchemlyb.preprocessing.subsampling` functions. The following are needed to complete this PR:
- [ ] tests
- [ ] usage example(s)
- [ ] preprocessing documentation for `bootstrapping` submodule
- [ ] addition to base estimator class
- [ ] at least one block bootstrapping implementation

In addition to the function(s), we additionally want to add a bootstrapping keyword (or set of keywords) to each estimator's constructor, which changes how uncertainties are estimated internally to the estimator at the expense of more compute. This will be the approach we will push users toward using for simplicity, but we still want to expose the building blocks by way of the`bootstrapping` module functions to allow for scaling out if needed (e.g. with dask).

As for block bootstrapping, we want to include an approach that bootstraps whole blocks of a timeseries instead of individual samples from that timeseries. Blocks should be defined based on the correlation time determined from the timeseries, or alternatively specified by the user. There are at least a few ways to do this, so this may require more debate and development. The advantage of block bootstrapping is that the resulting bootstrapped samples maintain correlation within their blocks, which may be desirable in some cases.