### PR TITLE
Removed redundant lines for calculating statistical inefficiency

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,24 @@ The rules for this file:
 ------------------------------------------------------------------------------
 
 
+??/??/2020 wehs7661, dotsdl
+
+* 0.?.?
+
+Enhancements
+
+Deprecations
+
+Fixes
+  - removed redundant statistical inefficiency calculation in
+  `alchemlyb.preprocessing.subsampling.equilibrium_detection`
+
+
+Changes
+
+
+
+
 01/16/2020 dotsdl, orbeckst
 
 * 0.3.1

--- a/src/alchemlyb/preprocessing/subsampling.py
+++ b/src/alchemlyb/preprocessing/subsampling.py
@@ -186,9 +186,6 @@ def equilibrium_detection(df, series=None, lower=None, upper=None, step=None):
     if series is not None:
         series = slicing(series, lower=lower, upper=upper, step=step)
 
-        # calculate statistical inefficiency of series
-        statinef  = statisticalInefficiency(series)
-
         # calculate statistical inefficiency of series, with equilibrium detection
         t, statinef, Neff_max  = detectEquilibration(series.values)
 


### PR DESCRIPTION
Removed redundant lines for calculating statistical inefficiency. 
For more information, please see Issue #96. Thank you.