### PR TITLE
WIP: Refactor of subsampling module

### DIFF
--- a/docs/preprocessing/alchemlyb.preprocessing.subsampling.rst
+++ b/docs/preprocessing/alchemlyb.preprocessing.subsampling.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: alchemlyb.preprocessing.subsampling
+
 .. _subsampling:
 
 Subsampling
@@ -5,7 +7,262 @@ Subsampling
 
 .. automodule:: alchemlyb.preprocessing.subsampling
 
-The functions featured in this module can be used to easily subsample either :ref:`dHdl <dHdl>` or :ref:`u_nk <u_nk>` datasets to give less correlated timeseries.
+The functions featured in this module can be used to easily subsample either :math:`\frac{dH}{d\lambda}` (:ref:`dHdl <dHdl>`) or :math:`u_{nk}` (:ref:`u_nk <u_nk>`) datasets to give uncorrelated timeseries.
+
+Each of these functions splits the dataset into groups based on :math:`\lambda` index values, with each group featuring all samples with the same :math:`\lambda` values.
+The function then performs its core operation (described below) on each group individually, with samples sorted according to the outermost ``time`` index beforehand.
+Each of these groups therefore functions as an individual *timeseries* being subsampled.
+The resulting :py:class:`pandas.DataFrame` is the concatenation of all groups after they have been subsampled.
+
+
+Slicing
+-------
+The :func:`~alchemlyb.preprocessing.subsampling.slicing` function only performs slicing of the dataset on the basis of ``time``.
+The ``lower`` and ``upper`` keyword specify the lower and upper bounds, *inclusive*, while ``step`` indicates the degree to which rows are skipped (e.g. ``step=2`` means to keep every other sample within the bounds).
+
+For example, if we have::
+
+    >>> u_nk
+                            0.00      0.25      0.50       0.75       1.00
+    time    fep-lambda                                                    
+    0.0     0.0         0.309323  3.656838  7.004353  10.351868  13.699383
+    10.0    0.0         0.308844  2.616688  4.924532   7.232376   9.540220
+    20.0    0.0         0.300940  1.626739  2.952538   4.278337   5.604136
+    30.0    0.0         0.309712  1.579647  2.849583   4.119518   5.389454
+    40.0    0.0         0.299979  2.255387  4.210794   6.166202   8.121610
+    ...                      ...       ...       ...        ...        ...
+    39960.0 1.0         3.913594  3.011197  2.108801   1.206405   0.304009
+    39970.0 1.0        -0.365724 -0.197390 -0.029055   0.139279   0.307614
+    39980.0 1.0         1.495407  1.199280  0.903152   0.607024   0.310897
+    39990.0 1.0         1.578606  1.260235  0.941863   0.623492   0.305121
+    40000.0 1.0         0.715197  0.611187  0.507178   0.403169   0.299160
+    
+    [20005 rows x 5 columns]
+
+Then we can grab all samples between :math:`t = 35.0` and :math:`t = 200.0`, inclusive::
+    
+    >>> slicing(u_nk, lower=35.0, upper=200.0)
+                          0.00      0.25      0.50      0.75       1.00
+    time  fep-lambda                                                   
+    40.0  0.0         0.299979  2.255387  4.210794  6.166202   8.121610
+    50.0  0.0         0.301968  3.209507  6.117047  9.024587  11.932126
+    60.0  0.0         0.308315  2.284146  4.259977  6.235809   8.211640
+    70.0  0.0         0.311610  2.773057  5.234504  7.695950  10.157397
+    80.0  0.0         0.301432  1.397817  2.494203  3.590589   4.686975
+    ...                    ...       ...       ...       ...        ...
+    160.0 1.0         1.396968  1.122475  0.847982  0.573489   0.298995
+    170.0 1.0        -1.812027 -1.283715 -0.755404 -0.227092   0.301219
+    180.0 1.0         0.979355  0.810205  0.641054  0.471904   0.302754
+    190.0 1.0        -2.455231 -1.766201 -1.077171 -0.388141   0.300889
+    200.0 1.0         2.419113  1.890386  1.361659  0.832932   0.304205
+    
+    [85 rows x 5 columns]
+
+
+In practice, this approach is not much different than directly using :py:property:`pandas.DataFrame.loc`::
+
+    >>> lower, upper, step = (35.0, 200.0, 1)
+    >>> u_nk.loc[lower:upper:step]
+
+The :func:`~alchemlyb.preprocessing.subsampling.slicing` function, however, performs some additional checks,
+such as ensuring there are not duplicate time values in the dataset, which can happen if data from repeat simulations were concatenated together prior to use.
+It's generally advisable to use subsampling functions on data from repeat simulations with ``time`` overlap *individually*, only concatenating afterward just before use with an :ref:`estimator <estimators>`.
+
+
+.. _subsampling_statinef:
+
+Statistical Inefficiency
+------------------------
+The :func:`~alchemlyb.preprocessing.subsampling.statistical_inefficiency` function subsamples each timeseries in the dataset by its calculated *statistical inefficiency*, :math:`g`, defined as:
+
+.. math::
+
+    g \equiv (1 + 2\tau) > 1
+
+where :math:`\tau` is the autocorrelation time of the timeseries.
+:math:`g` therefore functions as the spacing between uncorrelated samples in the timeseries.
+The timeseries is sliced with the :math:`\text{ceil}(g)` as its step (in the conservative case, see the API docs below).
+
+For example, if we have::
+
+    >>> u_nk
+                            0.00      0.25      0.50       0.75       1.00
+    time    fep-lambda                                                    
+    0.0     0.0         0.309323  3.656838  7.004353  10.351868  13.699383
+    10.0    0.0         0.308844  2.616688  4.924532   7.232376   9.540220
+    20.0    0.0         0.300940  1.626739  2.952538   4.278337   5.604136
+    30.0    0.0         0.309712  1.579647  2.849583   4.119518   5.389454
+    40.0    0.0         0.299979  2.255387  4.210794   6.166202   8.121610
+    ...                      ...       ...       ...        ...        ...
+    39960.0 1.0         3.913594  3.011197  2.108801   1.206405   0.304009
+    39970.0 1.0        -0.365724 -0.197390 -0.029055   0.139279   0.307614
+    39980.0 1.0         1.495407  1.199280  0.903152   0.607024   0.310897
+    39990.0 1.0         1.578606  1.260235  0.941863   0.623492   0.305121
+    40000.0 1.0         0.715197  0.611187  0.507178   0.403169   0.299160
+    
+    [20005 rows x 5 columns]
+
+We can extract uncorrelated samples for each ``fep-lambda`` with::
+
+    >>> statistical_inefficiency(u_nk, how='right')
+                            0.00      0.25      0.50       0.75       1.00
+    time    fep-lambda                                                    
+    0.0     0.0         0.309323  3.656838  7.004353  10.351868  13.699383
+    20.0    0.0         0.300940  1.626739  2.952538   4.278337   5.604136
+    40.0    0.0         0.299979  2.255387  4.210794   6.166202   8.121610
+    60.0    0.0         0.308315  2.284146  4.259977   6.235809   8.211640
+    80.0    0.0         0.301432  1.397817  2.494203   3.590589   4.686975
+    ...                      ...       ...       ...        ...        ...
+    39920.0 1.0         3.175234  2.457369  1.739504   1.021640   0.303775
+    39940.0 1.0        -1.480193 -1.034104 -0.588015  -0.141925   0.304164
+    39960.0 1.0         3.913594  3.011197  2.108801   1.206405   0.304009
+    39980.0 1.0         1.495407  1.199280  0.903152   0.607024   0.310897
+    40000.0 1.0         0.715197  0.611187  0.507178   0.403169   0.299160
+    
+    [12005 rows x 5 columns]
+
+The ``how`` parameter indicates the choice of observable for performing the calculation of :math:`g`.
+
+* For :math:`u_{nk}` datasets, the choice of ``'right'`` is recommended: the column immediately to the right of the column corresponding to the group's lambda index value is used as the observable.
+* For :math:`\frac{dH}{d\lambda}` datasets, the choice of ``'sum'`` is recommended: the columns are simply summed, and the resulting :py:class:`pandas.Series` is used as the observable.
+
+See the API documentation below on the possible values for ``how``, as well as more detailed explanations for each choice.
+
+It is also possible to choose a specific column, or an arbitrary :py:class:`pandas.Series` (with an *exactly* matching index to the dataset), as the basis for calculating :math:`g`::
+
+    >>> statistical_inefficiency(u_nk, column=0.75)
+                            0.00      0.25      0.50       0.75       1.00
+    time    fep-lambda                                                    
+    0.0     0.0         0.309323  3.656838  7.004353  10.351868  13.699383
+    20.0    0.0         0.300940  1.626739  2.952538   4.278337   5.604136
+    40.0    0.0         0.299979  2.255387  4.210794   6.166202   8.121610
+    60.0    0.0         0.308315  2.284146  4.259977   6.235809   8.211640
+    80.0    0.0         0.301432  1.397817  2.494203   3.590589   4.686975
+    ...                      ...       ...       ...        ...        ...
+    39920.0 1.0         3.175234  2.457369  1.739504   1.021640   0.303775
+    39940.0 1.0        -1.480193 -1.034104 -0.588015  -0.141925   0.304164
+    39960.0 1.0         3.913594  3.011197  2.108801   1.206405   0.304009
+    39980.0 1.0         1.495407  1.199280  0.903152   0.607024   0.310897
+    40000.0 1.0         0.715197  0.611187  0.507178   0.403169   0.299160
+    
+    [12005 rows x 5 columns]
+
+    >>> statistical_inefficiency(u_nk, column=u_nk[0.75])
+                            0.00      0.25      0.50       0.75       1.00
+    time    fep-lambda                                                    
+    0.0     0.0         0.309323  3.656838  7.004353  10.351868  13.699383
+    20.0    0.0         0.300940  1.626739  2.952538   4.278337   5.604136
+    40.0    0.0         0.299979  2.255387  4.210794   6.166202   8.121610
+    60.0    0.0         0.308315  2.284146  4.259977   6.235809   8.211640
+    80.0    0.0         0.301432  1.397817  2.494203   3.590589   4.686975
+    ...                      ...       ...       ...        ...        ...
+    39920.0 1.0         3.175234  2.457369  1.739504   1.021640   0.303775
+    39940.0 1.0        -1.480193 -1.034104 -0.588015  -0.141925   0.304164
+    39960.0 1.0         3.913594  3.011197  2.108801   1.206405   0.304009
+    39980.0 1.0         1.495407  1.199280  0.903152   0.607024   0.310897
+    40000.0 1.0         0.715197  0.611187  0.507178   0.403169   0.299160
+    
+    [12005 rows x 5 columns]
+
+See :py:func:`pymbar.timeseries.statisticalInefficiency` for more details; this is used internally by this subsampler.
+Please reference the following if you use this function in your research:
+
+    [1] J. D. Chodera, W. C. Swope, J. W. Pitera, C. Seok, and K. A. Dill. Use of the weighted histogram analysis method for the analysis of simulated and parallel tempering simulations. JCTC 3(1):26-41, 2007.
+
+
+Equilibrium Detection
+---------------------
+The :func:`~alchemlyb.preprocessing.subsampling.equilibrium_detection` function subsamples each timeseries in the dataset using the equilibration detection approach developed by John Chodera (see reference below).
+
+For each sorted timeseries in the dataset, and for each sample in each timeseries, the sample is treated as the starting point of the trajectory and the *statistical inefficiency*, :math:`g`, calculated.
+Each of these starting points yields an *effective* number of uncorrelated samples, :math:`N_{\text{eff}}`, and the starting point with the greatest :math:`N_{\text{eff}}` is chosen as the start of the *equilibrated* region of the trajectory.
+
+The sorted timeseries is then subsampled by dropping the samples prior to the chosen starting point, then slicing the remaining samples with :math:`\text{ceil}(g)` as its step (in the conservative case, see the API docs below).
+
+For example, if we have::
+
+    >>> u_nk
+                            0.00      0.25      0.50       0.75       1.00
+    time    fep-lambda                                                    
+    0.0     0.0         0.309323  3.656838  7.004353  10.351868  13.699383
+    10.0    0.0         0.308844  2.616688  4.924532   7.232376   9.540220
+    20.0    0.0         0.300940  1.626739  2.952538   4.278337   5.604136
+    30.0    0.0         0.309712  1.579647  2.849583   4.119518   5.389454
+    40.0    0.0         0.299979  2.255387  4.210794   6.166202   8.121610
+    ...                      ...       ...       ...        ...        ...
+    39960.0 1.0         3.913594  3.011197  2.108801   1.206405   0.304009
+    39970.0 1.0        -0.365724 -0.197390 -0.029055   0.139279   0.307614
+    39980.0 1.0         1.495407  1.199280  0.903152   0.607024   0.310897
+    39990.0 1.0         1.578606  1.260235  0.941863   0.623492   0.305121
+    40000.0 1.0         0.715197  0.611187  0.507178   0.403169   0.299160
+    
+    [20005 rows x 5 columns]
+
+We can extract uncorrelated samples for each ``fep-lambda`` with::
+
+    >>> equilibrium_detection(u_nk, how='right')
+                            0.00      0.25      0.50       0.75       1.00
+    time    fep-lambda                                                    
+    0.0     0.0         0.309323  3.656838  7.004353  10.351868  13.699383
+    20.0    0.0         0.300940  1.626739  2.952538   4.278337   5.604136
+    40.0    0.0         0.299979  2.255387  4.210794   6.166202   8.121610
+    60.0    0.0         0.308315  2.284146  4.259977   6.235809   8.211640
+    80.0    0.0         0.301432  1.397817  2.494203   3.590589   4.686975
+    ...                      ...       ...       ...        ...        ...
+    39820.0 1.0         5.238549  4.004569  2.770589   1.536609   0.302630
+    39840.0 1.0        -1.611068 -1.133603 -0.656139  -0.178674   0.298791
+    39860.0 1.0         0.052599  0.116262  0.179924   0.243587   0.307249
+    39880.0 1.0         1.312812  1.060874  0.808936   0.556998   0.305060
+    39900.0 1.0         6.940932  5.280870  3.620806   1.960743   0.300680
+    
+    [11968 rows x 5 columns]
+
+The ``how`` parameter indicates the choice of observable for performing the calculation of :math:`g`.
+See the brief recommendations for ``how`` in the :ref:`subsampling_statinef` section above, or the API documentation below on the possible values for ``how`` as well as more detailed explanations for each choice.
+
+It is also possible to choose a specific column, or an arbitrary :py:class:`pandas.Series` (with an *exactly* matching index to the dataset), as the basis for subsampling with equilibrium detection::
+
+    >>> equilibrium_detection(u_nk, column=0.75)
+                            0.00      0.25      0.50       0.75       1.00
+    time    fep-lambda                                                    
+    0.0     0.0         0.309323  3.656838  7.004353  10.351868  13.699383
+    20.0    0.0         0.300940  1.626739  2.952538   4.278337   5.604136
+    40.0    0.0         0.299979  2.255387  4.210794   6.166202   8.121610
+    60.0    0.0         0.308315  2.284146  4.259977   6.235809   8.211640
+    80.0    0.0         0.301432  1.397817  2.494203   3.590589   4.686975
+    ...                      ...       ...       ...        ...        ...
+    39820.0 1.0         5.238549  4.004569  2.770589   1.536609   0.302630
+    39840.0 1.0        -1.611068 -1.133603 -0.656139  -0.178674   0.298791
+    39860.0 1.0         0.052599  0.116262  0.179924   0.243587   0.307249
+    39880.0 1.0         1.312812  1.060874  0.808936   0.556998   0.305060
+    39900.0 1.0         6.940932  5.280870  3.620806   1.960743   0.300680
+    
+    [11961 rows x 5 columns]
+
+    >>> equilibrium_detection(u_nk, column=u_nk[0.75])
+                            0.00      0.25      0.50       0.75       1.00
+    time    fep-lambda                                                    
+    0.0     0.0         0.309323  3.656838  7.004353  10.351868  13.699383
+    20.0    0.0         0.300940  1.626739  2.952538   4.278337   5.604136
+    40.0    0.0         0.299979  2.255387  4.210794   6.166202   8.121610
+    60.0    0.0         0.308315  2.284146  4.259977   6.235809   8.211640
+    80.0    0.0         0.301432  1.397817  2.494203   3.590589   4.686975
+    ...                      ...       ...       ...        ...        ...
+    39820.0 1.0         5.238549  4.004569  2.770589   1.536609   0.302630
+    39840.0 1.0        -1.611068 -1.133603 -0.656139  -0.178674   0.298791
+    39860.0 1.0         0.052599  0.116262  0.179924   0.243587   0.307249
+    39880.0 1.0         1.312812  1.060874  0.808936   0.556998   0.305060
+    39900.0 1.0         6.940932  5.280870  3.620806   1.960743   0.300680
+    
+    [11961 rows x 5 columns]
+
+See :py:func:`pymbar.timeseries.detectEquilibration` for more details; this is used internally by this subsampler.
+Please reference the following if you use this function in your research:
+
+    [1] John D. Chodera. A simple method for automated equilibration detection in molecular simulations.  Journal of Chemical Theory and Computation, 12:1799, 2016.
+
+    [2] J. D. Chodera, W. C. Swope, J. W. Pitera, C. Seok, and K. A. Dill. Use of the weighted histogram analysis method for the analysis of simulated and parallel tempering simulations. JCTC 3(1):26-41, 2007.
+
 
 API Reference
 -------------

--- a/src/alchemlyb/preprocessing/subsampling.py
+++ b/src/alchemlyb/preprocessing/subsampling.py
@@ -1,22 +1,23 @@
 """Functions for subsampling datasets.
 
 """
+
+from collections import defaultdict
 import numpy as np
-from pymbar.timeseries import (statisticalInefficiency,
-                               detectEquilibration,
-                               subsampleCorrelatedData, )
+import pandas as pd
+from pymbar import timeseries
 
 
 def _check_multiple_times(df):
     return df.sort_index(0).reset_index(0).duplicated('time').any()
 
 
-def _check_sorted(df):
-    return df.reset_index(0)['time'].is_monotonic_increasing
-
-
 def slicing(df, lower=None, upper=None, step=None, force=False):
-    """Subsample a DataFrame using simple slicing.
+    """Subsample an alchemlyb DataFrame using slicing on the outermost index (time).
+
+    Slicing will be performed separately on groups of rows corresponding to
+    each set of lambda values present in the DataFrame's index. Each group will
+    be sorted on the outermost (time) index prior to slicing.
 
     Parameters
     ----------
@@ -37,60 +38,62 @@ def slicing(df, lower=None, upper=None, step=None, force=False):
         `df` subsampled.
 
     """
-    try:
-        df = df.loc[lower:upper:step]
-    except KeyError:
-        raise KeyError("DataFrame rows must be sorted by time, increasing.")
+    # we always start with a full index sort on the whole dataframe
+    df = df.sort_index()
 
-    if not force and _check_multiple_times(df):
-        raise KeyError("Duplicate time values found; it's generally advised "
-                       "to use slicing on DataFrames with unique time values "
-                       "for each row. Use `force=True` to ignore this error.")
+    index_names = list(df.index.names[1:])
+    resdf = list()
 
-    # drop any rows that have missing values
-    df = df.dropna()
+    for name, group in df.groupby(level=index_names):
+        group_s = group.loc[lower:upper:step]
 
-    return df
+        if not force and _check_multiple_times(group_s):
+            raise KeyError("Duplicate time values found; it's generally advised "
+                           "to use slicing on DataFrames with unique time values "
+                           "for each row. Use `force=True` to ignore this error.")
+
+        resdf.append(group_s)
+
+    return pd.concat(resdf)
 
 
-def statistical_inefficiency(df, series=None, lower=None, upper=None, step=None,
-                             conservative=True):
-    """Subsample a DataFrame based on the calculated statistical inefficiency
-    of a timeseries.
+def statistical_inefficiency(df, column, lower=None, upper=None, step=None,
+                             conservative=True, return_calculated=False, force=False):
+    """Subsample an alchemlyb DataFrame based on the calculated statistical inefficiency
+    of one of its columns.
 
-    If `series` is ``None``, then this function will behave the same as
-    :func:`slicing`.
+    Calculation of statistical inefficiency and subsequent subsampling will be
+    performed separately on groups of rows corresponding to each set of lambda
+    values present in the DataFrame's index. Each group will be sorted on the
+    outermost (time) index prior to any calculation.
 
     Parameters
     ----------
     df : DataFrame
         DataFrame to subsample according statistical inefficiency of `series`.
-    series : Series
-        Series to use for calculating statistical inefficiency. If ``None``,
-        no statistical inefficiency-based subsampling will be performed.
+    column : label
+        Label of column to use for calculating statistical inefficiency.
     lower : float
-        Lower bound to pre-slice `series` data from.
+        Lower time to pre-slice data from.
     upper : float
-        Upper bound to pre-slice `series` to (inclusive).
+        Upper time to pre-slice data to (inclusive).
     step : int
-        Step between `series` items to pre-slice by.
+        Step between rows to pre-slice by.
     conservative : bool
         ``True`` use ``ceil(statistical_inefficiency)`` to slice the data in uniform
         intervals (the default). ``False`` will sample at non-uniform intervals to
         closely match the (fractional) statistical_inefficieny, as implemented
         in :func:`pymbar.timeseries.subsampleCorrelatedData`.
+    return_calculated : bool
+        ``True`` return a tuple, with the second item a dict giving, e.g. `statinef`
+        for each group.
+    force : bool
+        Ignore checks that DataFrame is in proper form for expected behavior.
 
     Returns
     -------
     DataFrame
-        `df` subsampled according to subsampled `series`.
-
-    Warning
-    -------
-    The `series` and the data to be sliced, `df`, need to have the same number
-    of elements because the statistical inefficiency is calculated based on
-    the index of the series (and not an associated time). At the moment there is
-    no automatic conversion from a time to an index.
+        `df` subsampled according to subsampled `column`.
 
     Note
     ----
@@ -108,95 +111,155 @@ def statistical_inefficiency(df, series=None, lower=None, upper=None, step=None,
     pymbar.timeseries.subsampleCorrelatedData : used for subsampling
 
 
+    .. versionchanged:: 0.4.0
+       The ``series`` keyword was replaced with the ``column`` keyword.
+       The function no longer takes an arbitrary series as input for
+       calculating statistical inefficiency.
+
     .. versionchanged:: 0.2.0
        The ``conservative`` keyword was added and the method is now using
-       ``pymbar.timeseries.statisticalInefficiency()``; previously, the statistical
+       ``pymbar.timeseries.subsampleCorrelatedData()``; previously, the statistical
        inefficiency was _rounded_ (instead of ``ceil()``) and thus one could
        end up with correlated data.
 
     """
-    if _check_multiple_times(df):
-        raise KeyError("Duplicate time values found; statistical inefficiency "
-                       "only works on a single, contiguous, "
-                       "and sorted timeseries.")
+    # we always start with a full index sort on the whole dataframe
+    df = df.sort_index()
 
-    if not _check_sorted(df):
-        raise KeyError("Statistical inefficiency only works as expected if "
-                       "values are sorted by time, increasing.")
+    index_names = list(df.index.names[1:])
+    resdf = list()
 
-    if series is not None:
-        series = slicing(series, lower=lower, upper=upper, step=step)
+    if return_calculated:
+        calculated = defaultdict(dict)
 
-        if (len(series) != len(df) or
-            not all(series.reset_index()['time'] == df.reset_index()['time'])):
-            raise ValueError("series and data must be sampled at the same times")
+    for name, group in df.groupby(level=index_names):
+            
+        group_s = slicing(group, lower=lower, upper=upper, step=step)
 
-        # calculate statistical inefficiency of series (could use fft=True but needs test)
-        statinef  = statisticalInefficiency(series, fast=False)
+        if not force and _check_multiple_times(group):
+            raise KeyError("Duplicate time values found; statistical inefficiency"
+                           "is only meaningful for a single, contiguous, "
+                           "and sorted timeseries.")
+
+        # calculate statistical inefficiency of column (could use fft=True but needs test)
+        statinef = timeseries.statisticalInefficiency(group_s[column], fast=False)
 
         # use the subsampleCorrelatedData function to get the subsample index
-        indices = subsampleCorrelatedData(series, g=statinef,
-                                          conservative=conservative)
-        df = df.iloc[indices]
+        indices = timeseries.subsampleCorrelatedData(group_s[column], g=statinef,
+                                      conservative=conservative)
+
+        resdf.append(group_s.iloc[indices])
+
+        if return_calculated:
+            calculated['statinef'][name] = statinef
+    
+    if return_calculated:
+        return pd.concat(resdf), calculated
     else:
-        df = slicing(df, lower=lower, upper=upper, step=step)
-
-    return df
+        return pd.concat(resdf)
 
 
-def equilibrium_detection(df, series=None, lower=None, upper=None, step=None):
-    """Subsample a DataFrame using automated equilibrium detection on a timeseries.
+def equilibrium_detection(df, column, lower=None, upper=None, step=None,
+                          conservative=True, return_calculated=False, force=False):
+    """Subsample a DataFrame using automated equilibrium detection on one of
+    its columns.
 
-    If `series` is ``None``, then this function will behave the same as
-    :func:`slicing`.
+    Equilibrium detection and subsequent subsampling will be performed
+    separately on groups of rows corresponding to each set of lambda values
+    present in the DataFrame's index. Each group will be sorted on the
+    outermost (time) index prior to any calculation.
 
     Parameters
     ----------
     df : DataFrame
         DataFrame to subsample according to equilibrium detection on `series`.
-    series : Series
-        Series to detect equilibration on. If ``None``, no equilibrium
-        detection-based subsampling will be performed.
+    column : label
+        Label of column to use for equilibrium detection.
     lower : float
-        Lower bound to pre-slice `series` data from.
+        Lower time to pre-slice data from.
     upper : float
-        Upper bound to pre-slice `series` to (inclusive).
+        Upper time to pre-slice data to (inclusive).
     step : int
-        Step between `series` items to pre-slice by.
+        Step between rows to pre-slice by.
+    conservative : bool
+        ``True`` use ``ceil(statistical_inefficiency)`` to slice the data in uniform
+        intervals (the default). ``False`` will sample at non-uniform intervals to
+        closely match the (fractional) statistical_inefficieny, as implemented
+        in :func:`pymbar.timeseries.subsampleCorrelatedData`.
+    return_calculated : bool
+        ``True`` return a tuple, with the second item a dict giving, e.g. `statinef`
+        for each group.
+    force : bool
+        Ignore checks that DataFrame is in proper form for expected behavior.
 
     Returns
     -------
     DataFrame
-        `df` subsampled according to subsampled `series`.
+        `df` subsampled according to subsampled `column`.
+
+    Note
+    ----
+    For a non-integer statistical ineffciency :math:`g`, the default value
+    ``conservative=True`` will provide _fewer_ data points than allowed by
+    :math:`g` and thus error estimates will be _higher_. For large numbers of
+    data points and converged free energies, the choice should not make a
+    difference. For small numbers of data points, ``conservative=True``
+    decreases a false sense of accuracy and is deemed the more careful and
+    conservative approach.
 
     See Also
     --------
     pymbar.timeseries.detectEquilibration : detailed background
+    pymbar.timeseries.subsampleCorrelatedData : used for subsampling
+
+
+    .. versionchanged:: 0.4.0
+       The ``series`` keyword was replaced with the ``column`` keyword.
+       The function no longer takes an arbitrary series as input for
+       calculating statistical inefficiency.
+
+    .. versionchanged:: 0.4.0
+       The ``conservative`` keyword was added and the method is now using
+       ``pymbar.timeseries.subsampleCorrelatedData()``; previously, the statistical
+       inefficiency was _rounded_ (instead of ``ceil()``) and thus one could
+       end up with correlated data.
 
     """
-    if _check_multiple_times(df):
-        raise KeyError("Duplicate time values found; equilibrium detection "
-                       "is only meaningful for a single, contiguous, "
-                       "and sorted timeseries.")
+    # we always start with a full index sort on the whole dataframe
+    df = df.sort_index()
 
-    if not _check_sorted(df):
-        raise KeyError("Equilibrium detection only works as expected if "
-                       "values are sorted by time, increasing.")
+    index_names = list(df.index.names[1:])
+    resdf = list()
 
-    if series is not None:
-        series = slicing(series, lower=lower, upper=upper, step=step)
+    if return_calculated:
+        calculated = defaultdict(dict)
+
+    for name, group in df.groupby(level=index_names):
+        group_s = slicing(group, lower=lower, upper=upper, step=step)
+
+        if not force and _check_multiple_times(group):
+            raise KeyError("Duplicate time values found; equilibrium detection "
+                           "is only meaningful for a single, contiguous, "
+                           "and sorted timeseries.")
 
         # calculate statistical inefficiency of series, with equilibrium detection
-        t, statinef, Neff_max  = detectEquilibration(series.values)
+        t, statinef, Neff_max  = timeseries.detectEquilibration(group_s[column])
 
-        # we round up
-        statinef = int(np.rint(statinef))
+        # only keep values past `t`
+        group_s = group_s.iloc[t:]
 
-        # subsample according to statistical inefficiency
-        series = series.iloc[t::statinef]
+        # use the subsampleCorrelatedData function to get the subsample index
+        indices = timeseries.subsampleCorrelatedData(group_s[column], g=statinef,
+                                      conservative=conservative)
 
-        df = df.loc[series.index]
+        resdf.append(group_s.iloc[indices])
+
+        if return_calculated:
+            calculated['t'][name] = statinef
+            calculated['statinef'][name] = statinef
+            calculated['Neff_max'][name] = statinef
+
+    if return_calculated:
+        return pd.concat(resdf), calculated
     else:
-        df = slicing(df, lower=lower, upper=upper, step=step)
-
-    return df
+        return pd.concat(resdf)

--- a/src/alchemlyb/tests/test_fep_estimators.py
+++ b/src/alchemlyb/tests/test_fep_estimators.py
@@ -19,6 +19,8 @@ def gmx_benzene_coul_u_nk():
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['Coulomb']])
 
+    u_nk.attrs['alchemform'] = 'u_nk'
+
     return u_nk
 
 def gmx_benzene_vdw_u_nk():
@@ -26,6 +28,8 @@ def gmx_benzene_vdw_u_nk():
 
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['VDW']])
+
+    u_nk.attrs['alchemform'] = 'u_nk'
 
     return u_nk
 
@@ -35,6 +39,8 @@ def gmx_expanded_ensemble_case_1():
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
+    u_nk.attrs['alchemform'] = 'u_nk'
+
     return u_nk
 
 def gmx_expanded_ensemble_case_2():
@@ -42,6 +48,8 @@ def gmx_expanded_ensemble_case_2():
 
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
+
+    u_nk.attrs['alchemform'] = 'u_nk'
 
     return u_nk
 
@@ -51,6 +59,8 @@ def gmx_expanded_ensemble_case_3():
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
+    u_nk.attrs['alchemform'] = 'u_nk'
+
     return u_nk
 
 def gmx_water_particle_with_total_energy():
@@ -58,6 +68,8 @@ def gmx_water_particle_with_total_energy():
 
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
+
+    u_nk.attrs['alchemform'] = 'u_nk'
 
     return u_nk
 
@@ -67,6 +79,8 @@ def gmx_water_particle_with_potential_energy():
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
+    u_nk.attrs['alchemform'] = 'u_nk'
+
     return u_nk
 
 def gmx_water_particle_without_energy():
@@ -75,6 +89,8 @@ def gmx_water_particle_without_energy():
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
+    u_nk.attrs['alchemform'] = 'u_nk'
+
     return u_nk
 
 def amber_bace_example_complex_vdw():
@@ -82,6 +98,8 @@ def amber_bace_example_complex_vdw():
 
     u_nk = pd.concat([amber.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['complex']['vdw']])
+    u_nk.attrs['alchemform'] = 'u_nk'
+
     return u_nk
 
 def gomc_benzene_u_nk():
@@ -89,6 +107,8 @@ def gomc_benzene_u_nk():
 
     u_nk = pd.concat([gomc.extract_u_nk(filename, T=298)
                       for filename in dataset['data']])
+
+    u_nk.attrs['alchemform'] = 'u_nk'
 
     return u_nk
 
@@ -101,7 +121,10 @@ def namd_tyr2ala():
     u_nk1[u_nk1.isna()] = u_nk2
     u_nk = u_nk1.sort_index(level=u_nk1.index.names[1:])
 
+    u_nk.attrs['alchemform'] = 'u_nk'
+
     return u_nk
+
 
 class FEPestimatorMixin:
     """Mixin for all FEP Estimator test classes.

--- a/src/alchemlyb/tests/test_fep_estimators.py
+++ b/src/alchemlyb/tests/test_fep_estimators.py
@@ -19,8 +19,6 @@ def gmx_benzene_coul_u_nk():
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['Coulomb']])
 
-    u_nk.attrs['alchemform'] = 'u_nk'
-
     return u_nk
 
 def gmx_benzene_vdw_u_nk():
@@ -28,8 +26,6 @@ def gmx_benzene_vdw_u_nk():
 
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['VDW']])
-
-    u_nk.attrs['alchemform'] = 'u_nk'
 
     return u_nk
 
@@ -39,8 +35,6 @@ def gmx_expanded_ensemble_case_1():
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
-    u_nk.attrs['alchemform'] = 'u_nk'
-
     return u_nk
 
 def gmx_expanded_ensemble_case_2():
@@ -48,8 +42,6 @@ def gmx_expanded_ensemble_case_2():
 
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
-
-    u_nk.attrs['alchemform'] = 'u_nk'
 
     return u_nk
 
@@ -59,8 +51,6 @@ def gmx_expanded_ensemble_case_3():
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
-    u_nk.attrs['alchemform'] = 'u_nk'
-
     return u_nk
 
 def gmx_water_particle_with_total_energy():
@@ -68,8 +58,6 @@ def gmx_water_particle_with_total_energy():
 
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
-
-    u_nk.attrs['alchemform'] = 'u_nk'
 
     return u_nk
 
@@ -79,8 +67,6 @@ def gmx_water_particle_with_potential_energy():
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
-    u_nk.attrs['alchemform'] = 'u_nk'
-
     return u_nk
 
 def gmx_water_particle_without_energy():
@@ -89,8 +75,6 @@ def gmx_water_particle_without_energy():
     u_nk = pd.concat([gmx.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
-    u_nk.attrs['alchemform'] = 'u_nk'
-
     return u_nk
 
 def amber_bace_example_complex_vdw():
@@ -98,8 +82,6 @@ def amber_bace_example_complex_vdw():
 
     u_nk = pd.concat([amber.extract_u_nk(filename, T=300)
                       for filename in dataset['data']['complex']['vdw']])
-    u_nk.attrs['alchemform'] = 'u_nk'
-
     return u_nk
 
 def gomc_benzene_u_nk():
@@ -107,8 +89,6 @@ def gomc_benzene_u_nk():
 
     u_nk = pd.concat([gomc.extract_u_nk(filename, T=298)
                       for filename in dataset['data']])
-
-    u_nk.attrs['alchemform'] = 'u_nk'
 
     return u_nk
 
@@ -120,8 +100,6 @@ def namd_tyr2ala():
     # combine dataframes of fwd and rev directions
     u_nk1[u_nk1.isna()] = u_nk2
     u_nk = u_nk1.sort_index(level=u_nk1.index.names[1:])
-
-    u_nk.attrs['alchemform'] = 'u_nk'
 
     return u_nk
 

--- a/src/alchemlyb/tests/test_preprocessing.py
+++ b/src/alchemlyb/tests/test_preprocessing.py
@@ -10,7 +10,65 @@ from alchemlyb.parsing import gmx
 from alchemlyb.preprocessing import (slicing, statistical_inefficiency,
                                      equilibrium_detection,)
 
+from . import test_ti_estimators as tti
+from . import test_fep_estimators as tfep
+
 import alchemtest.gmx
+
+@pytest.fixture(scope="module",
+                params = [(tti.gmx_benzene_coul_dHdl, "single", 0),
+                          (tti.gmx_benzene_vdw_dHdl, "single", 0),
+                          (tti.gmx_expanded_ensemble_case_1_dHdl, "single", 1),
+                          (tti.gmx_expanded_ensemble_case_2_dHdl, "repeat", 1),
+                          (tti.gmx_expanded_ensemble_case_3_dHdl, "repeat", 1),
+                          (tti.gmx_water_particle_with_total_energy_dHdl, "single", 0),
+                          (tti.gmx_water_particle_with_potential_energy_dHdl, "single", 0),
+                          (tti.gmx_water_particle_without_energy_dHdl, "single", 0),
+                          (tti.amber_simplesolvated_charge_dHdl, "single", 0),
+                          (tti.amber_simplesolvated_vdw_dHdl, "single", 0)
+                ],
+                ids = ["tti.gmx_benzene_coul_dHdl",
+                       "tti.gmx_benzene_vdw_dHdl",
+                       "tti.gmx_expanded_ensemble_case_1_dHdl",
+                       "tti.gmx_expanded_ensemble_case_2_dHdl",
+                       "tti.gmx_expanded_ensemble_case_3_dHdl",
+                       "tti.gmx_water_particle_with_total_energy_dHdl",
+                       "tti.gmx_water_particle_with_potential_energy_dHdl",
+                       "tti.gmx_water_particle_without_energy_dHdl",
+                       "tti.amber_simplesolvated_charge_dHdl",
+                       "tti.amber_simplesolvated_vdw_dHdl",
+                ])
+def dHdl(request):
+    get_dHdl, nsims, column_index = request.param
+    return get_dHdl(), nsims, column_index
+
+
+@pytest.fixture(scope="class",
+                params=[(tfep.gmx_benzene_coul_u_nk, "single", 0),
+                        (tfep.gmx_benzene_vdw_u_nk, "single", 0),
+                        (tfep.gmx_expanded_ensemble_case_1, "single", 0),
+                        (tfep.gmx_expanded_ensemble_case_2, "repeat", 0),
+                        (tfep.gmx_expanded_ensemble_case_3, "repeat", 0),
+                        (tfep.gmx_water_particle_with_total_energy, "single", 0),
+                        (tfep.gmx_water_particle_with_potential_energy, "single", 0),
+                        (tfep.gmx_water_particle_without_energy, "single", -1),
+                        (tfep.amber_bace_example_complex_vdw, "single", -1),
+                        (tfep.gomc_benzene_u_nk, "single", 0),
+                ],
+                ids = ["tfep.gmx_benzene_coul_u_nk",
+                       "tfep.gmx_benzene_vdw_u_nk",
+                       "tfep.gmx_expanded_ensemble_case_1",
+                       "tfep.gmx_expanded_ensemble_case_2",
+                       "tfep.gmx_expanded_ensemble_case_3",
+                       "tfep.gmx_water_particle_with_total_energy",
+                       "tfep.gmx_water_particle_with_potential_energy",
+                       "tfep.gmx_water_particle_without_energy",
+                       "tfep.amber_bace_example_complex_vdw",
+                       "tfep.gomc_benzene_u_nk",
+                ])
+def u_nk(request):
+    get_unk, nsims, column_index = request.param
+    return get_unk(), nsims, column_index
 
 
 def gmx_benzene_dHdl():
@@ -49,13 +107,13 @@ class TestSlicing:
     """Test slicing functionality.
 
     """
-    def slicer(self, *args, **kwargs):
+    def subsampler(self, *args, **kwargs):
         return slicing(*args, **kwargs)
 
     @pytest.mark.parametrize(('data', 'size'), [(gmx_benzene_dHdl(), 661),
                                                 (gmx_benzene_u_nk(), 661)])
     def test_basic_slicing(self, data, size):
-        assert len(self.slicer(data, lower=1000, upper=34000, step=5)) == size
+        assert len(self.subsampler(data, lower=1000, upper=34000, step=5)) == size
 
     @pytest.mark.parametrize('data', [gmx_benzene_dHdl(),
                                       gmx_benzene_u_nk()])
@@ -68,16 +126,36 @@ class TestSlicing:
 
         df = data.iloc[indices]
 
-        assert (self.slicer(df, lower=200) == self.slicer(data, lower=200)).all().all()
+        assert (self.subsampler(df, lower=200) == self.subsampler(data, lower=200)).all().all()
 
     @pytest.mark.parametrize('data', [gmx_benzene_dHdl_duplicated(),
                                       gmx_benzene_u_nk_duplicated()])
     def test_duplicated_exception(self, data):
-        """Test that a DataFrame with duplicate times yields a KeyError.
+        """Test that a DataFrame with duplicate times for a lambda combination
+        yields a KeyError.
 
         """
         with pytest.raises(KeyError):
-            self.slicer(data, lower=200)
+            self.subsampler(data, lower=200)
+
+    def test_slicing_dHdl(self, dHdl):
+        data, nsims, column_index = dHdl
+
+        if nsims == "single":
+            dHdl_s = self.subsampler(data)
+        elif nsims == "repeat":
+            with pytest.raises(KeyError):
+                dHdl_s = self.subsampler(data)
+
+    def test_slicing_u_nk(self, u_nk):
+        data, nsims, column_index = u_nk 
+        
+        if nsims == "single":
+            u_nk_s = self.subsampler(data)
+        elif nsims == "repeat":
+            with pytest.raises(KeyError):
+                u_nk_s = self.subsampler(data)
+
 
 class CorrelatedPreprocessors:
 
@@ -87,12 +165,32 @@ class CorrelatedPreprocessors:
         """Basic test for execution; resulting size of dataset sensitive to
         machine and depends on algorithm.
         """
-        assert len(self.slicer(data, data.columns[0])) <= size
+        assert len(self.subsampler(data, data.columns[0])) <= size
+
+    def test_subsampling_dHdl(self, dHdl):
+        data, nsims, column_index = dHdl
+
+        if nsims == "single":
+            dHdl_s = self.subsampler(data, data.columns[column_index])
+            assert len(dHdl_s) < data
+        elif nsims == "repeat":
+            with pytest.raises(KeyError):
+                dHdl_s = self.subsampler(data, data.columns[column_index])
+
+    def test_subsampling_u_nk(self, u_nk):
+        data, nsims, column_index = u_nk 
+
+        if nsims == "single":
+            u_nk_s = self.subsampler(data, data.columns[column_index])
+            assert len(u_nk_s) < data
+        elif nsims == "repeat":
+            with pytest.raises(KeyError):
+                u_nk_s = self.subsampler(data, data.columns[column_index])
 
 
 class TestStatisticalInefficiency(CorrelatedPreprocessors):
 
-    def slicer(self, *args, **kwargs):
+    def subsampler(self, *args, **kwargs):
         return statistical_inefficiency(*args, **kwargs)
 
     @pytest.mark.parametrize(('conservative', 'data', 'size'),
@@ -103,7 +201,7 @@ class TestStatisticalInefficiency(CorrelatedPreprocessors):
                                  (False, gmx_benzene_u_nk(), 3571),
                              ])
     def test_conservative(self, data, size, conservative):
-        sliced = self.slicer(data, data.columns[0], conservative=conservative)
+        sliced = self.subsampler(data, data.columns[0], conservative=conservative)
         # results can vary slightly with different machines
         # so possibly do
         # delta = 10
@@ -112,5 +210,5 @@ class TestStatisticalInefficiency(CorrelatedPreprocessors):
 
 class TestEquilibriumDetection(CorrelatedPreprocessors):
 
-    def slicer(self, *args, **kwargs):
+    def subsampler(self, *args, **kwargs):
         return equilibrium_detection(*args, **kwargs)

--- a/src/alchemlyb/tests/test_preprocessing.py
+++ b/src/alchemlyb/tests/test_preprocessing.py
@@ -233,7 +233,7 @@ class TestStatisticalInefficiency(CorrelatedPreprocessors):
         assert len(sliced) == size
 
 
-class TestEquilibriumDetection():
+class TestEquilibriumDetection(CorrelatedPreprocessors):
 
     def subsampler(self, *args, **kwargs):
         return equilibrium_detection(*args, **kwargs)

--- a/src/alchemlyb/tests/test_preprocessing.py
+++ b/src/alchemlyb/tests/test_preprocessing.py
@@ -16,16 +16,16 @@ from . import test_fep_estimators as tfep
 import alchemtest.gmx
 
 @pytest.fixture(scope="module",
-                params = [(tti.gmx_benzene_coul_dHdl, "single", 0),
-                          (tti.gmx_benzene_vdw_dHdl, "single", 0),
-                          (tti.gmx_expanded_ensemble_case_1_dHdl, "single", 1),
-                          (tti.gmx_expanded_ensemble_case_2_dHdl, "repeat", 1),
-                          (tti.gmx_expanded_ensemble_case_3_dHdl, "repeat", 1),
-                          (tti.gmx_water_particle_with_total_energy_dHdl, "single", 0),
-                          (tti.gmx_water_particle_with_potential_energy_dHdl, "single", 0),
-                          (tti.gmx_water_particle_without_energy_dHdl, "single", 0),
-                          (tti.amber_simplesolvated_charge_dHdl, "single", 0),
-                          (tti.amber_simplesolvated_vdw_dHdl, "single", 0)
+                params = [(tti.gmx_benzene_coul_dHdl, "single"),
+                          (tti.gmx_benzene_vdw_dHdl, "single"),
+                          (tti.gmx_expanded_ensemble_case_1_dHdl, "single"),
+                          (tti.gmx_expanded_ensemble_case_2_dHdl, "repeat"),
+                          (tti.gmx_expanded_ensemble_case_3_dHdl, "repeat"),
+                          (tti.gmx_water_particle_with_total_energy_dHdl, "single"),
+                          (tti.gmx_water_particle_with_potential_energy_dHdl, "single"),
+                          (tti.gmx_water_particle_without_energy_dHdl, "single"),
+                          (tti.amber_simplesolvated_charge_dHdl, "single"),
+                          (tti.amber_simplesolvated_vdw_dHdl, "single")
                 ],
                 ids = ["tti.gmx_benzene_coul_dHdl",
                        "tti.gmx_benzene_vdw_dHdl",
@@ -39,21 +39,21 @@ import alchemtest.gmx
                        "tti.amber_simplesolvated_vdw_dHdl",
                 ])
 def dHdl(request):
-    get_dHdl, nsims, column_index = request.param
-    return get_dHdl(), nsims, column_index
+    get_dHdl, nsims = request.param
+    return get_dHdl(), nsims
 
 
 @pytest.fixture(scope="class",
-                params=[(tfep.gmx_benzene_coul_u_nk, "single", 0),
-                        (tfep.gmx_benzene_vdw_u_nk, "single", 0),
-                        (tfep.gmx_expanded_ensemble_case_1, "single", 0),
-                        (tfep.gmx_expanded_ensemble_case_2, "repeat", 0),
-                        (tfep.gmx_expanded_ensemble_case_3, "repeat", 0),
-                        (tfep.gmx_water_particle_with_total_energy, "single", 0),
-                        (tfep.gmx_water_particle_with_potential_energy, "single", 0),
-                        (tfep.gmx_water_particle_without_energy, "single", -1),
-                        (tfep.amber_bace_example_complex_vdw, "single", -1),
-                        (tfep.gomc_benzene_u_nk, "single", 0),
+                params=[(tfep.gmx_benzene_coul_u_nk, "single"),
+                        (tfep.gmx_benzene_vdw_u_nk, "single"),
+                        (tfep.gmx_expanded_ensemble_case_1, "single"),
+                        (tfep.gmx_expanded_ensemble_case_2, "repeat"),
+                        (tfep.gmx_expanded_ensemble_case_3, "repeat"),
+                        (tfep.gmx_water_particle_with_total_energy, "single"),
+                        (tfep.gmx_water_particle_with_potential_energy, "single"),
+                        (tfep.gmx_water_particle_without_energy, "single"),
+                        (tfep.amber_bace_example_complex_vdw, "single"),
+                        (tfep.gomc_benzene_u_nk, "single"),
                 ],
                 ids = ["tfep.gmx_benzene_coul_u_nk",
                        "tfep.gmx_benzene_vdw_u_nk",
@@ -67,40 +67,64 @@ def dHdl(request):
                        "tfep.gomc_benzene_u_nk",
                 ])
 def u_nk(request):
-    get_unk, nsims, column_index = request.param
-    return get_unk(), nsims, column_index
+    get_unk, nsims = request.param
+    return get_unk(), nsims
 
 
 def gmx_benzene_dHdl():
     dataset = alchemtest.gmx.load_benzene()
-    return gmx.extract_dHdl(dataset['data']['Coulomb'][0], T=300)
+    dHdl = gmx.extract_dHdl(dataset['data']['Coulomb'][0], T=300)
+
+    dHdl.attrs['alchemform'] = 'dHdl'
+
+    return dHdl
 
 
 def gmx_benzene_dHdl_duplicated():
     dataset = alchemtest.gmx.load_benzene()
     df = gmx.extract_dHdl(dataset['data']['Coulomb'][0], T=300)
-    return pd.concat([df, df])
+    dHdl = pd.concat([df, df])
+
+    dHdl.attrs['alchemform'] = 'dHdl'
+
+    return dHdl
 
 
 def gmx_benzene_u_nk():
     dataset = alchemtest.gmx.load_benzene()
-    return gmx.extract_u_nk(dataset['data']['Coulomb'][0], T=300)
+    u_nk = gmx.extract_u_nk(dataset['data']['Coulomb'][0], T=300)
+
+    u_nk.attrs['alchemform'] = 'u_nk'
+
+    return u_nk
 
 
 def gmx_benzene_u_nk_duplicated():
     dataset = alchemtest.gmx.load_benzene()
     df = gmx.extract_u_nk(dataset['data']['Coulomb'][0], T=300)
-    return pd.concat([df, df])
+    u_nk = pd.concat([df, df])
+
+    u_nk.attrs['alchemform'] = 'u_nk'
+
+    return u_nk
 
 
 def gmx_benzene_dHdl_full():
     dataset = alchemtest.gmx.load_benzene()
-    return pd.concat([gmx.extract_dHdl(i, T=300) for i in dataset['data']['Coulomb']])
+    dHdl = pd.concat([gmx.extract_dHdl(i, T=300) for i in dataset['data']['Coulomb']])
+
+    dHdl.attrs['alchemform'] = 'dHdl'
+
+    return dHdl
 
 
 def gmx_benzene_u_nk_full():
     dataset = alchemtest.gmx.load_benzene()
     return pd.concat([gmx.extract_u_nk(i, T=300) for i in dataset['data']['Coulomb']])
+
+    u_nk.attrs['alchemform'] = 'u_nk'
+
+    return u_nk
 
 
 class TestSlicing:
@@ -139,7 +163,7 @@ class TestSlicing:
             self.subsampler(data, lower=200)
 
     def test_slicing_dHdl(self, dHdl):
-        data, nsims, column_index = dHdl
+        data, nsims = dHdl
 
         if nsims == "single":
             dHdl_s = self.subsampler(data)
@@ -148,7 +172,7 @@ class TestSlicing:
                 dHdl_s = self.subsampler(data)
 
     def test_slicing_u_nk(self, u_nk):
-        data, nsims, column_index = u_nk 
+        data, nsims = u_nk 
         
         if nsims == "single":
             u_nk_s = self.subsampler(data)
@@ -165,27 +189,27 @@ class CorrelatedPreprocessors:
         """Basic test for execution; resulting size of dataset sensitive to
         machine and depends on algorithm.
         """
-        assert len(self.subsampler(data, data.columns[0])) <= size
+        assert len(self.subsampler(data)) <= size
 
     def test_subsampling_dHdl(self, dHdl):
-        data, nsims, column_index = dHdl
+        data, nsims = dHdl
 
         if nsims == "single":
-            dHdl_s = self.subsampler(data, data.columns[column_index])
-            assert len(dHdl_s) < data
+            dHdl_s = self.subsampler(data)
+            assert len(dHdl_s) < len(data)
         elif nsims == "repeat":
             with pytest.raises(KeyError):
-                dHdl_s = self.subsampler(data, data.columns[column_index])
+                dHdl_s = self.subsampler(data)
 
     def test_subsampling_u_nk(self, u_nk):
-        data, nsims, column_index = u_nk 
+        data, nsims = u_nk 
 
         if nsims == "single":
-            u_nk_s = self.subsampler(data, data.columns[column_index])
-            assert len(u_nk_s) < data
+            u_nk_s = self.subsampler(data)
+            assert len(u_nk_s) < len(data)
         elif nsims == "repeat":
             with pytest.raises(KeyError):
-                u_nk_s = self.subsampler(data, data.columns[column_index])
+                u_nk_s = self.subsampler(data)
 
 
 class TestStatisticalInefficiency(CorrelatedPreprocessors):
@@ -198,17 +222,18 @@ class TestStatisticalInefficiency(CorrelatedPreprocessors):
                                  (True, gmx_benzene_dHdl(), 2001),  # 0.00:  g = 1.0559445620585415
                                  (True, gmx_benzene_u_nk(), 2001),  # 'fep': g = 1.0560203916559594
                                  (False, gmx_benzene_dHdl(), 3789),
-                                 (False, gmx_benzene_u_nk(), 3571),
+                                 (False, gmx_benzene_u_nk(), 3788),
                              ])
     def test_conservative(self, data, size, conservative):
-        sliced = self.subsampler(data, data.columns[0], conservative=conservative)
+        sliced = self.subsampler(data, conservative=conservative)
         # results can vary slightly with different machines
         # so possibly do
         # delta = 10
         # assert size - delta < len(sliced) < size + delta
         assert len(sliced) == size
 
-class TestEquilibriumDetection(CorrelatedPreprocessors):
+
+class TestEquilibriumDetection():
 
     def subsampler(self, *args, **kwargs):
         return equilibrium_detection(*args, **kwargs)

--- a/src/alchemlyb/tests/test_ti_estimators.py
+++ b/src/alchemlyb/tests/test_ti_estimators.py
@@ -18,6 +18,8 @@ def gmx_benzene_coul_dHdl():
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['Coulomb']])
 
+    dHdl.attrs['alchemform'] = 'dHdl'
+
     return dHdl
 
 def gmx_benzene_vdw_dHdl():
@@ -25,6 +27,8 @@ def gmx_benzene_vdw_dHdl():
 
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['VDW']])
+
+    dHdl.attrs['alchemform'] = 'dHdl'
 
     return dHdl
 
@@ -34,6 +38,8 @@ def gmx_expanded_ensemble_case_1_dHdl():
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
+    dHdl.attrs['alchemform'] = 'dHdl'
+
     return dHdl
 
 def gmx_expanded_ensemble_case_2_dHdl():
@@ -41,6 +47,8 @@ def gmx_expanded_ensemble_case_2_dHdl():
 
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
+
+    dHdl.attrs['alchemform'] = 'dHdl'
 
     return dHdl
 
@@ -50,6 +58,8 @@ def gmx_expanded_ensemble_case_3_dHdl():
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
+    dHdl.attrs['alchemform'] = 'dHdl'
+
     return dHdl
 
 def gmx_water_particle_with_total_energy_dHdl():
@@ -57,6 +67,8 @@ def gmx_water_particle_with_total_energy_dHdl():
 
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
+
+    dHdl.attrs['alchemform'] = 'dHdl'
 
     return dHdl
 
@@ -66,6 +78,8 @@ def gmx_water_particle_with_potential_energy_dHdl():
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
+    dHdl.attrs['alchemform'] = 'dHdl'
+
     return dHdl
 
 def gmx_water_particle_without_energy_dHdl():
@@ -73,6 +87,8 @@ def gmx_water_particle_without_energy_dHdl():
 
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
+
+    dHdl.attrs['alchemform'] = 'dHdl'
 
     return dHdl
 
@@ -82,6 +98,8 @@ def amber_simplesolvated_charge_dHdl():
     dHdl = pd.concat([amber.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['charge']])
 
+    dHdl.attrs['alchemform'] = 'dHdl'
+
     return dHdl
 
 def amber_simplesolvated_vdw_dHdl():
@@ -90,6 +108,8 @@ def amber_simplesolvated_vdw_dHdl():
     dHdl = pd.concat([amber.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['vdw']])
 
+    dHdl.attrs['alchemform'] = 'dHdl'
+
     return dHdl
 
 def gomc_benzene_dHdl():
@@ -97,6 +117,8 @@ def gomc_benzene_dHdl():
 
     dHdl = pd.concat([gomc.extract_dHdl(filename, T=298)
                       for filename in dataset['data']])
+
+    dHdl.attrs['alchemform'] = 'dHdl'
 
     return dHdl
 

--- a/src/alchemlyb/tests/test_ti_estimators.py
+++ b/src/alchemlyb/tests/test_ti_estimators.py
@@ -18,8 +18,6 @@ def gmx_benzene_coul_dHdl():
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['Coulomb']])
 
-    dHdl.attrs['alchemform'] = 'dHdl'
-
     return dHdl
 
 def gmx_benzene_vdw_dHdl():
@@ -27,8 +25,6 @@ def gmx_benzene_vdw_dHdl():
 
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['VDW']])
-
-    dHdl.attrs['alchemform'] = 'dHdl'
 
     return dHdl
 
@@ -38,8 +34,6 @@ def gmx_expanded_ensemble_case_1_dHdl():
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
-    dHdl.attrs['alchemform'] = 'dHdl'
-
     return dHdl
 
 def gmx_expanded_ensemble_case_2_dHdl():
@@ -47,8 +41,6 @@ def gmx_expanded_ensemble_case_2_dHdl():
 
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
-
-    dHdl.attrs['alchemform'] = 'dHdl'
 
     return dHdl
 
@@ -58,8 +50,6 @@ def gmx_expanded_ensemble_case_3_dHdl():
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
-    dHdl.attrs['alchemform'] = 'dHdl'
-
     return dHdl
 
 def gmx_water_particle_with_total_energy_dHdl():
@@ -67,8 +57,6 @@ def gmx_water_particle_with_total_energy_dHdl():
 
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
-
-    dHdl.attrs['alchemform'] = 'dHdl'
 
     return dHdl
 
@@ -78,8 +66,6 @@ def gmx_water_particle_with_potential_energy_dHdl():
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
 
-    dHdl.attrs['alchemform'] = 'dHdl'
-
     return dHdl
 
 def gmx_water_particle_without_energy_dHdl():
@@ -87,8 +73,6 @@ def gmx_water_particle_without_energy_dHdl():
 
     dHdl = pd.concat([gmx.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['AllStates']])
-
-    dHdl.attrs['alchemform'] = 'dHdl'
 
     return dHdl
 
@@ -98,8 +82,6 @@ def amber_simplesolvated_charge_dHdl():
     dHdl = pd.concat([amber.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['charge']])
 
-    dHdl.attrs['alchemform'] = 'dHdl'
-
     return dHdl
 
 def amber_simplesolvated_vdw_dHdl():
@@ -108,8 +90,6 @@ def amber_simplesolvated_vdw_dHdl():
     dHdl = pd.concat([amber.extract_dHdl(filename, T=300)
                       for filename in dataset['data']['vdw']])
 
-    dHdl.attrs['alchemform'] = 'dHdl'
-
     return dHdl
 
 def gomc_benzene_dHdl():
@@ -117,8 +97,6 @@ def gomc_benzene_dHdl():
 
     dHdl = pd.concat([gomc.extract_dHdl(filename, T=298)
                       for filename in dataset['data']])
-
-    dHdl.attrs['alchemform'] = 'dHdl'
 
     return dHdl
 


### PR DESCRIPTION
Addresses #95, #79, #91 

Required for merge:
- [x] reference documentation for the functions included in the `alchemlyb.preprocessing.subsampling` module
- [ ] example notebook showing usage, as well as rationale for usage, of each function
- [x] tests across more datasets in `alchemtest`
- [ ] changelog entry

This is an API breaking change.

All three of our subsampling functions should now be able to consume any DataFrame in our two standard `u_nk` and `dHdl` forms and produce meaningful results. Each of these functions now performs a `groupby` with all non-time indexes, and separately performs its operation on each group. The resulting subsampled groups are concatenated and returned.

Some notes on the implementation:
1. The `series` kwarg is now the `column` kwarg for  `statistical_inefficiency`, `equilibrium_detection`. This can take either a column name in the DataFrame or a Series object (the index of the Series must match *exactly* that of the DataFrame). Taking a Series object allows for code that uses the existing usage of e.g. `statistical_inefficiency(u_nk, u_nk[<column_name>])` to still work as before.
2. `statistical_inefficiency` and `equilibrium_detection` now have a `how` kwarg. I expect this to be the main usage we suggest for users of these functions. I took a look at how `alchemical_analysis` [currently handles `dHdl` and `u_nk` cases](https://github.com/MobleyLab/alchemical-analysis/blob/master/alchemical_analysis/alchemical_analysis.py#L159), and to replicate that as closely as possible, we recommend using `how='right'` for `u_nk` data, and `how='sum'` for `dHdl` data. Please see the docstrings for `statistical_inefficiency`, `equilibrium_detection` for details on these treatments.
3. Either `column` or `how` must be used for `statistical_inefficiency`, `equilibrium_detection`. The function can no longer default to simple slicing if only `data` is given as an input. This is to avoid (potentially new) users from applying the functions without specifying these inputs with no obvious failure, but with the function doing nothing to decorrelate their data (essentially a silent failure).
4. I've added the `force` kwarg to `statistical_inefficiency`, `equilibrium_detection`. The only exception these functions will skip with `force=True` is one due to duplicate time values in the groupings, as this tends to indicate two or more timeseries have been dumped together, which is unlikely what one wants to do with these subsampling functions that assume correlation to work as intended.
5. Setting `return_calculated=True` for `statistical_inefficiency`, `equilibrium_detection` will return calculated values used for subsampling each lambda grouping:
    - `statistical_inefficiency`: `statinef`
    - `equilibrium_detection`: `t`, `statinef`, `Neff_max`

Some other nice things:
1. I will be adding the minimal assumptions the standard forms make to their doc page as part of this change's PR. One of the assumptions I want to propagate is that the outermost index is *always* time, or at least something implying time (frame, sample, whatever). It needn't be called 'time', however, for all the tooling to work.
2. These subsamplers now explicitly call out that they *can't be expected* to preserve any custom ordering of rows. They will always be doing sorting of some kind, so the time index values are meaningful.