### PR TITLE
update environment.yml with matplotlib and python 3.7

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,9 @@
 name: alchemlyb
 dependencies:
-- python=3.5
+- python=3.7
 - numpy
 - scipy
 - pandas
 - scikit-learn
+- matplotlib
 - sphinx

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,17 @@
 ---
-conda:
-    file: environment.yml
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+formats:
+  - pdf
 
 python:
-    setup_py_install: true
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+
+conda:
+    environment: environment.yml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -15,3 +15,5 @@ python:
 
 conda:
     environment: environment.yml
+
+

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -15,5 +15,3 @@ python:
 
 conda:
     environment: environment.yml
-
-


### PR DESCRIPTION
RTD fails to build, probably because we added matplotlib to the dependencies.

EDIT: mpl is ok but the Python version needs to be > 3.5 (which I already did with the bump to 3.7)