### PR TITLE
allow statistical_inefficieny to handle multi-index timeseries

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,7 +20,10 @@ The rules for this file:
 * 0.?.?
 
 Enhancements
-  - Allow the overlap matrix of the MBAR estimator to be plotted. (issue #73, PR #107)
+  - Allow statistical_inefficiency to work on multiindex series. (issue #116,
+  PR #117)
+  - Allow the overlap matrix of the MBAR estimator to be plotted. (issue #73,
+  PR #107)
   - Allow the dhdl of the TI estimator to be plotted. (issue #73, PR #110)
   - Allow the dF states to be plotted. (issue #73, PR #112)
 

--- a/src/alchemlyb/preprocessing/subsampling.py
+++ b/src/alchemlyb/preprocessing/subsampling.py
@@ -2,13 +2,17 @@
 
 """
 import numpy as np
+import pandas as pd
 from pymbar.timeseries import (statisticalInefficiency,
                                detectEquilibration,
                                subsampleCorrelatedData, )
 
 
 def _check_multiple_times(df):
-    return df.sort_index(0).reset_index(0).duplicated('time').any()
+    if isinstance(df, pd.Series):
+        return df.sort_index(0).reset_index('time', name='').duplicated('time').any()
+    else:
+        return df.sort_index(0).reset_index('time').duplicated('time').any()
 
 
 def _check_sorted(df):

--- a/src/alchemlyb/tests/test_preprocessing.py
+++ b/src/alchemlyb/tests/test_preprocessing.py
@@ -18,6 +18,12 @@ def gmx_benzene_dHdl():
     return gmx.extract_dHdl(dataset['data']['Coulomb'][0], T=300)
 
 
+@pytest.fixture()
+def gmx_ABFE():
+    dataset = alchemtest.gmx.load_ABFE()
+    return gmx.extract_u_nk(dataset['data']['complex'][0], T=300)
+
+
 def gmx_benzene_u_nk():
     dataset = alchemtest.gmx.load_benzene()
     return gmx.extract_u_nk(dataset['data']['Coulomb'][0], T=300)
@@ -66,6 +72,11 @@ class TestSlicing:
         """
         with pytest.raises(KeyError):
             self.slicer(data.sort_index(0), lower=200)
+
+    def test_multiindex_duplicated(self, gmx_ABFE):
+        subsample = statistical_inefficiency(gmx_ABFE,
+                                             gmx_ABFE.sum(axis=1))
+        assert len(subsample) == 501
 
 
 class CorrelatedPreprocessors:


### PR DESCRIPTION
fix #116 

This PR uses the new test file from https://github.com/alchemistry/alchemtest/pull/41 so won't succeed until that one is merged.