### PR TITLE
Make it that the MBAR will take in maximum_iterations argument.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,7 @@ Fixes
     compatible with pandas.concat() (issue #150, PR #152).
   - Fix the support for pandas >= 1.3 by skipping 1.3.0 (issue #147, PR #148).
   - Fix separate_dhdl not work for multiple columns (issue #149, PR #151).
+  - MBAR estimator now correctly passes max_iterations to pymbar.MBAR. (PR #162)
   
 
 06/08/2021 orbeckst

--- a/src/alchemlyb/estimators/mbar_.py
+++ b/src/alchemlyb/estimators/mbar_.py
@@ -53,7 +53,7 @@ class MBAR(BaseEstimator):
         self.maximum_iterations = maximum_iterations
         self.relative_tolerance = relative_tolerance
         self.initial_f_k = initial_f_k
-        self.method = [dict(method=method)]
+        self.method = method
         self.verbose = verbose
 
         # handle for pymbar.MBAR object
@@ -77,12 +77,15 @@ class MBAR(BaseEstimator):
         groups = u_nk.groupby(level=u_nk.index.names[1:])
         N_k = [(len(groups.get_group(i)) if i in groups.groups else 0) for i in u_nk.columns]        
         
+        # Prepare the solver_protocol as stated in https://github.com/choderalab/pymbar/issues/419#issuecomment-803714103
+        solver_options = {"maximum_iterations": self.maximum_iterations,
+                          "verbose": self.verbose}
+        solver_protocol = {"method": self.method,
+                           "options": solver_options}
         self._mbar = MBAR_(u_nk.T, N_k,
-                           maximum_iterations=self.maximum_iterations,
                            relative_tolerance=self.relative_tolerance,
                            initial_f_k=self.initial_f_k,
-                           solver_protocol=self.method,
-                           verbose=self.verbose)
+                           solver_protocol=(solver_protocol,))
 
         self.states_ = u_nk.columns.values.tolist()
 

--- a/src/alchemlyb/tests/test_fep_estimators.py
+++ b/src/alchemlyb/tests/test_fep_estimators.py
@@ -206,15 +206,3 @@ class Test_Units():
         assert mbar.delta_f_.attrs['energy_unit'] == 'kT'
         assert mbar.d_delta_f_.attrs['temperature'] == 300
         assert mbar.d_delta_f_.attrs['energy_unit'] == 'kT'
-
-def test_MBAR_assign():
-    '''Test if the assignment is actually being passed into the MBAR'''
-    mbar = MBAR(maximum_iterations=1000,
-                relative_tolerance=1e-08,
-                initial_f_k=3, method='BFGS',
-                verbose=True)
-    assert mbar.initial_f_k == 3
-    assert mbar.relative_tolerance == 1e-08
-    assert mbar.maximum_iterations == 1000
-    assert mbar.method == 'BFGS'
-    assert mbar.verbose == True

--- a/src/alchemlyb/tests/test_fep_estimators.py
+++ b/src/alchemlyb/tests/test_fep_estimators.py
@@ -206,3 +206,15 @@ class Test_Units():
         assert mbar.delta_f_.attrs['energy_unit'] == 'kT'
         assert mbar.d_delta_f_.attrs['temperature'] == 300
         assert mbar.d_delta_f_.attrs['energy_unit'] == 'kT'
+
+def test_MBAR_assign():
+    '''Test if the assignment is actually being passed into the MBAR'''
+    mbar = MBAR(maximum_iterations=1000,
+                relative_tolerance=1e-08,
+                initial_f_k=3, method='BFGS',
+                verbose=True)
+    assert mbar.initial_f_k == 3
+    assert mbar.relative_tolerance == 1e-08
+    assert mbar.maximum_iterations == 1000
+    assert mbar.method == 'BFGS'
+    assert mbar.verbose == True


### PR DESCRIPTION
Currently, at least `maximum_iterations` is not really being used during the MBAR solver.
So I changed the MBAR to make sure that it is taken into account as is suggested in https://github.com/choderalab/pymbar/issues/419#issuecomment-803714103.

Note the doc says other things though https://pymbar.readthedocs.io/en/master/mbar.html.

I cannot write a test to test this as `pymbar.mbar.MBAR` doesn't have a public attribute that echoes this assignment.

It is hard to raise an issue either as the bug will show itself when MBAR didn't converge within the default 250 iterations and most of the calculations converge in less than 250 iterations.