### PR TITLE
Set a strict python minimum version for install, add automated pypi deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,6 @@ jobs:
         environment-name: test
         extra-specs: |
             python=${{ matrix.python-version }}
-            pytest=${{ matrix.pytest }}
 
     - name: Install alchemtest
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,16 @@ on:
     branches:
       - "master"
 
+
 concurrency:
-  group: "${{ github.ref }}-${{ github.head_ref }}"
+  group: "${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}"
   cancel-in-progress: true
+
+
+defaults:
+  run:
+    shell: bash -l {0}
+
 
 jobs:
   test:
@@ -25,7 +32,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]   
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
     - uses: mamba-org/provision-with-micromamba@main
@@ -37,28 +44,21 @@ jobs:
             pytest=${{ matrix.pytest }}
 
     - name: Install alchemtest
-      # conda setup requires this special shell
-      shell: bash -l {0}
       run: |
         python -m pip install https://github.com/alchemistry/alchemtest/archive/master.zip
 
     - name: Install package (with no dependencies)
-      # conda setup requires this special shell
-      shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
 
     - name: Run tests
-      # conda setup requires this special shell
-      shell: bash -l {0}
-
       run: |
         pytest -v --cov=alchemlyb --cov-report=xml --color=yes src/alchemlyb/tests
       env:
         MPLBACKEND: agg
 
     - name: Codecov
-      uses: codecov/codecov-action@v1.5.2
+      uses: codecov/codecov-action@v2
       with:
         name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
         file: ./coverage.xml

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,6 @@
 name: Build and upload to PyPI
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,7 @@ defaults:
 
 jobs:
   build_wheels:
-    environment: deploy
+    # environment: deploy
     if: "github.repository == 'alchemistry/alchemlyb'"
     name: Build pure Python wheel and tarball
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,7 @@
 name: Build and upload to PyPI
 
 on:
-  pull_requests:
+  pull_request:
     branches:
       - master
   push:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,7 @@ defaults:
 
 jobs:
   build_wheels:
-    # environment: deploy
+    environment: deploy
     if: "github.repository == 'alchemistry/alchemlyb'"
     name: Build pure Python wheel and tarball
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,67 @@
+name: Build and upload to PyPI
+
+on:
+  pull_requests:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+  release:
+    types:
+      - published
+
+
+concurrency:
+  group: "${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}"
+  cancel-in-progress: true
+
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+
+jobs:
+  build_wheels:
+    environment: deploy
+    if: "github.repository == 'alchemistry/alchemlyb'"
+    name: Build pure Python wheel and tarball
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: setup_miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.8
+          auto-update-conda: true
+          add-pip-as-python-dependency: true
+          architecture: x64
+
+      - name: install_deps
+        run: |
+          python -m pip install build
+
+      - name: build
+        run: |
+          python -m build --sdist --wheel --outdir dist/
+ 
+      - name: publish_testpypi
+        # Upload to testpypi on every tag
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: publish_pypi
+        if: github.event_name == 'release' && github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,6 @@ Chronological list of authors
   - Alexander Schlaich (@schlaicha)
   - Jérôme Hénin (@jhenin)
   - Thomas T. Joseph (@ttjoseph)
+
+2022
+  - Irfan Alibay (@IAlibay)

--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ The rules for this file:
   * 0.7.0
 
 Changes
+  - Deployment to PyPI is now done automatically using github actions
+    (Issue #193)
   - gmx parser now defaults to dropping NaN and corrupted lines (filter=True) 
     (#171, PR #183)
 
@@ -28,6 +30,8 @@ Enhancements
     incomplete/corrupted lines (#126, #171) with filter=True.
 
 Fixes
+  - Fixes setup.py and setup.cfg to prevent installations with Python versions
+    lower than 3.7 (Issue #193)
   - added AutoMBAR to convergence analysis (#189)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(name='alchemlyb',
       license='BSD',
       long_description=open('README.rst').read(),
       long_description_content_type='text/x-rst',
+      python_requires='>=3.7',
       tests_require = ['pytest', 'alchemtest'],
       install_requires=['numpy', 'pandas>=1.2,!=1.3.0', 'pymbar>=3.0.5,<4',
                         'scipy', 'scikit-learn', 'matplotlib']


### PR DESCRIPTION
Fixes #193 

Work done in this PR:
  - two small changes to setup.py and setup.cfg to enforce python>=3.7 and prevent universal wheels (which are meant to also work with py2) from being built.
  - Added automatic deployment to pypi on release, as per: https://github.com/MDAnalysis/GridDataFormats/blob/master/.github/workflows/deploy.yaml (I'm happy saying that bit of code is under BSD-3 if that works with you @orbeckst)