### PR TITLE
ABFE workflow will not read dHdl file if no TI estimator is choosen

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,9 @@ Changes
   - AutoMBAR accepts the `method` argument (PR #114).
   - Refactor the subsampling module to unify the behaviour of
     equilibrium_detection and statistical_inefficiency (PR #218).
+  - For ABFE workflow, dHdl will only be read when a TI estimator is chosen.
+    Similarly, u_nk will only be read when FEP estimators are chosen. (PR #231)
+
 
 Enhancements
   - Add u_nk2series and dhdl2series to convert u_nk and dHdl to series (PR

--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Changes
     equilibrium_detection and statistical_inefficiency (PR #218).
   - For ABFE workflow, dHdl will only be read when a TI estimator is chosen.
     Similarly, u_nk will only be read when FEP estimators are chosen. (PR #231)
+  - Remove the ignore_warnings flag in ABFE workflow. (PR #231)
 
 
 Enhancements

--- a/CHANGES
+++ b/CHANGES
@@ -24,8 +24,6 @@ Changes
   - AutoMBAR accepts the `method` argument (PR #114).
   - Refactor the subsampling module to unify the behaviour of
     equilibrium_detection and statistical_inefficiency (PR #218).
-  - For ABFE workflow, dHdl will only be read when a TI estimator is chosen.
-    Similarly, u_nk will only be read when FEP estimators are chosen. (PR #231)
   - Remove the ignore_warnings flag in ABFE workflow. (PR #231)
 
 
@@ -45,6 +43,8 @@ Fixes
     at which the simulations were run (issue #225, PR #232)
   - changed how int/float are read from AMBER files (issue #229, PR #235)
   - substitute the any_none() function with a check "if None in" in the AMBER parser (issue #236, PR #237)
+  - For ABFE workflow, dHdl will only be read when a TI estimator is chosen.
+    Similarly, u_nk will only be read when FEP estimators are chosen. (PR #231)
 
 07/22/2022 xiki-tempula, IAlibay, dotsdl, orbeckst, ptmerz
 

--- a/src/alchemlyb/tests/test_workflow_ABFE.py
+++ b/src/alchemlyb/tests/test_workflow_ABFE.py
@@ -276,7 +276,7 @@ class Test_methods():
     def test_run_single_estimator(self, workflow, monkeypatch):
         monkeypatch.setattr(workflow, 'u_nk_list', [])
         monkeypatch.setattr(workflow, 'dHdl_list', [])
-        workflow.run(uncorr=None, estimators='TI', overlap=None, breakdown=None,
+        workflow.run(uncorr=None, estimators='MBAR', overlap=None, breakdown=True,
                      forwrev=None)
 
     def test_run_invalid_estimator(self, workflow):

--- a/src/alchemlyb/tests/test_workflow_ABFE.py
+++ b/src/alchemlyb/tests/test_workflow_ABFE.py
@@ -273,23 +273,35 @@ class Test_methods():
         workflow.run(uncorr=None, estimators=None, overlap=None, breakdown=None,
                      forwrev=None)
 
-    def test_read_invalid_u_nk(self, workflow, monkeypatch):
+    @pytest.mark.parametrize('ignore_warnings', [True, False])
+    def test_read_invalid_u_nk(self, workflow, monkeypatch, ignore_warnings):
         def extract_u_nk(self, T):
             raise IOError('Error read u_nk.')
         monkeypatch.setattr(workflow, '_extract_u_nk',
                             extract_u_nk)
-        with pytest.raises(OSError,
-                           match=r'Error reading u_nk .*dhdl\.xvg\.bz2'):
-            workflow.read()
+        monkeypatch.setattr(workflow, 'ignore_warnings',
+                            ignore_warnings)
+        if not ignore_warnings:
+            with pytest.raises(OSError,
+                               match=r'Error reading u_nk .*dhdl\.xvg\.bz2'):
+                workflow.read()
+        else:
+            assert workflow.read() is None
 
-    def test_read_invalid_dHdl(self, workflow, monkeypatch):
+    @pytest.mark.parametrize('ignore_warnings', [True, False])
+    def test_read_invalid_dHdl(self, workflow, monkeypatch, ignore_warnings):
         def extract_dHdl(self, T):
             raise IOError('Error read dHdl.')
         monkeypatch.setattr(workflow, '_extract_dHdl',
                             extract_dHdl)
-        with pytest.raises(OSError,
-                           match=r'Error reading dHdl .*dhdl\.xvg\.bz2'):
-            workflow.read()
+        monkeypatch.setattr(workflow, 'ignore_warnings',
+                            ignore_warnings)
+        if not ignore_warnings:
+            with pytest.raises(OSError,
+                               match=r'Error reading dHdl .*dhdl\.xvg\.bz2'):
+                workflow.read()
+        else:
+            assert workflow.read() is None
 
     def test_uncorr_threshold(self, workflow, monkeypatch):
         '''Test if the full data will be used when the number of data points

--- a/src/alchemlyb/tests/test_workflow_ABFE.py
+++ b/src/alchemlyb/tests/test_workflow_ABFE.py
@@ -290,37 +290,23 @@ class Test_methods():
         else:
             assert len(workflow.dHdl_list) == 0
 
-    @pytest.mark.parametrize('ignore_warnings', [True, False])
-    def test_read_invalid_u_nk(self, workflow, monkeypatch, ignore_warnings, caplog):
+    def test_read_invalid_u_nk(self, workflow, monkeypatch):
         def extract_u_nk(self, T):
             raise IOError('Error read u_nk.')
         monkeypatch.setattr(workflow, '_extract_u_nk',
                             extract_u_nk)
-        monkeypatch.setattr(workflow, 'ignore_warnings',
-                            ignore_warnings)
-        if not ignore_warnings:
-            with pytest.raises(OSError,
-                               match=r'Error reading u_nk .*dhdl\.xvg\.bz2'):
-                workflow.read()
-        else:
-            with caplog.at_level(logging.ERROR):
-                workflow.read()
-                assert 'This exception is being ignored because ignore_warnings=True.' not in caplog.text
+        with pytest.raises(OSError,
+                           match=r'Error reading u_nk .*dhdl\.xvg\.bz2'):
+            workflow.read()
 
-    @pytest.mark.parametrize('ignore_warnings', [True, False])
-    def test_read_invalid_dHdl(self, workflow, monkeypatch, ignore_warnings):
+    def test_read_invalid_dHdl(self, workflow, monkeypatch):
         def extract_dHdl(self, T):
             raise IOError('Error read dHdl.')
         monkeypatch.setattr(workflow, '_extract_dHdl',
                             extract_dHdl)
-        monkeypatch.setattr(workflow, 'ignore_warnings',
-                            ignore_warnings)
-        if not ignore_warnings:
-            with pytest.raises(OSError,
-                               match=r'Error reading dHdl .*dhdl\.xvg\.bz2'):
-                workflow.read()
-        else:
-            assert workflow.read() is None
+        with pytest.raises(OSError,
+                           match=r'Error reading dHdl .*dhdl\.xvg\.bz2'):
+            workflow.read()
 
     def test_uncorr_threshold(self, workflow, monkeypatch):
         '''Test if the full data will be used when the number of data points

--- a/src/alchemlyb/tests/test_workflow_ABFE.py
+++ b/src/alchemlyb/tests/test_workflow_ABFE.py
@@ -273,6 +273,22 @@ class Test_methods():
         workflow.run(uncorr=None, estimators=None, overlap=None, breakdown=None,
                      forwrev=None)
 
+    @pytest.mark.parametrize('read_u_nk', [True, False])
+    @pytest.mark.parametrize('read_dHdl', [True, False])
+    def test_read_TI_FEP(self, workflow, monkeypatch, read_u_nk, read_dHdl):
+        monkeypatch.setattr(workflow, 'u_nk_list', [])
+        monkeypatch.setattr(workflow, 'dHdl_list', [])
+        workflow.read(read_u_nk, read_dHdl)
+        if read_u_nk:
+            assert len(workflow.u_nk_list) == 5
+        else:
+            assert len(workflow.u_nk_list) == 0
+
+        if read_dHdl:
+            assert len(workflow.dHdl_list) == 5
+        else:
+            assert len(workflow.dHdl_list) == 0
+
     @pytest.mark.parametrize('ignore_warnings', [True, False])
     def test_read_invalid_u_nk(self, workflow, monkeypatch, ignore_warnings):
         def extract_u_nk(self, T):

--- a/src/alchemlyb/tests/test_workflow_ABFE.py
+++ b/src/alchemlyb/tests/test_workflow_ABFE.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 import os
-import logging
 
 from alchemlyb.workflows.abfe import ABFE
 from alchemtest.gmx import load_ABFE, load_benzene
@@ -273,6 +272,18 @@ class Test_methods():
         '''Don't run anything'''
         workflow.run(uncorr=None, estimators=None, overlap=None, breakdown=None,
                      forwrev=None)
+
+    def test_run_single_estimator(self, workflow, monkeypatch):
+        monkeypatch.setattr(workflow, 'u_nk_list', [])
+        monkeypatch.setattr(workflow, 'dHdl_list', [])
+        workflow.run(uncorr=None, estimators='TI', overlap=None, breakdown=None,
+                     forwrev=None)
+
+    def test_run_invalid_estimator(self, workflow):
+        with pytest.raises(ValueError,
+                           match=r'Estimator aaa is not supported.'):
+            workflow.run(uncorr=None, estimators='aaa', overlap=None, breakdown=None,
+                         forwrev=None)
 
     @pytest.mark.parametrize('read_u_nk', [True, False])
     @pytest.mark.parametrize('read_dHdl', [True, False])

--- a/src/alchemlyb/workflows/abfe.py
+++ b/src/alchemlyb/workflows/abfe.py
@@ -233,7 +233,7 @@ class ABFE(WorkflowBase):
                     self.logger.error(msg)
                     raise ValueError(msg)
 
-        self.read(use_FEP, use_TI)
+            self.read(use_FEP, use_TI)
 
         if uncorr is not None:
             self.preprocess(skiptime=skiptime, uncorr=uncorr,

--- a/src/alchemlyb/workflows/abfe.py
+++ b/src/alchemlyb/workflows/abfe.py
@@ -148,12 +148,17 @@ class ABFE(WorkflowBase):
         if read_u_nk:
             self.logger.info('Sort files according to the u_nk.')
             column_names = u_nk_list[0].columns.values.tolist()
+            index_list = sorted(range(len(self.file_list)),
+                                key=lambda x: column_names.index(
+                                    u_nk_list[x].reset_index(
+                                        'time').index.values[0]))
         elif read_dHdl:
             self.logger.info('Sort files according to the dHdl.')
             column_names = dHdl_list[0].columns.values.tolist()
-        index_list = sorted(range(len(self.file_list)),
-            key=lambda x:column_names.index(
-                u_nk_list[x].reset_index('time').index.values[0]))
+            index_list = sorted(range(len(self.file_list)),
+                                key=lambda x: column_names.index(
+                                    dHdl_list[x].reset_index(
+                                        'time').index.values[0]))
 
         self.file_list = [self.file_list[i] for i in index_list]
         self.logger.info("Sorted file list: \n%s", '\n'.join(self.file_list))

--- a/src/alchemlyb/workflows/abfe.py
+++ b/src/alchemlyb/workflows/abfe.py
@@ -48,8 +48,6 @@ class ABFE(WorkflowBase):
     outdirectory : str
         Directory in which the output files produced by this script will be
         stored. Default: os.path.curdir.
-    ignore_warnings : bool
-        Turn all errors into warnings.
 
     Attributes
     ----------
@@ -60,11 +58,9 @@ class ABFE(WorkflowBase):
     '''
     def __init__(self, T, units='kT', software='GROMACS', dir=os.path.curdir,
                  prefix='dhdl', suffix='xvg',
-                 outdirectory=os.path.curdir,
-                 ignore_warnings=False):
+                 outdirectory=os.path.curdir):
 
         super().__init__(units, software, T, outdirectory)
-        self.ignore_warnings = ignore_warnings
         self.logger = logging.getLogger('alchemlyb.workflows.ABFE')
         self.logger.info('Initialise Alchemlyb ABFE Workflow')
         self.logger.info(f'Alchemlyb Version: f{__version__}')
@@ -125,12 +121,8 @@ class ABFE(WorkflowBase):
                     u_nk_list.append(u_nk)
                 except Exception as exc:
                     msg = f'Error reading u_nk from {file}.'
-                    if self.ignore_warnings:
-                        self.logger.exception(msg + f'\n{exc}\n' +
-                            'This exception is being ignored because ignore_warnings=True.')
-                    else:
-                        self.logger.error(msg)
-                        raise OSError(msg) from exc
+                    self.logger.error(msg)
+                    raise OSError(msg) from exc
 
             if read_dHdl:
                 try:
@@ -140,12 +132,8 @@ class ABFE(WorkflowBase):
                     dHdl_list.append(dhdl)
                 except Exception as exc:
                     msg = f'Error reading dHdl from {file}.'
-                    if self.ignore_warnings:
-                        self.logger.exception(msg + f'\n{exc}\n' +
-                            'This exception is being ignored because ignore_warnings=True.')
-                    else:
-                        self.logger.error(msg)
-                        raise OSError(msg) from exc
+                    self.logger.error(msg)
+                    raise OSError(msg) from exc
 
         # Sort the files according to the state
         if read_u_nk:

--- a/src/alchemlyb/workflows/abfe.py
+++ b/src/alchemlyb/workflows/abfe.py
@@ -219,18 +219,19 @@ class ABFE(WorkflowBase):
         use_FEP = False
         use_TI = False
 
-        if isinstance(estimators, str):
-            estimators = [estimators, ]
-        for estimator in estimators:
-            if estimator in FEP_ESTIMATORS:
-                use_FEP = True
-            elif estimator in TI_ESTIMATORS:
-                use_TI = True
-            else:
-                msg = f"Estimator {estimator} is not supported. Choose one from " \
-                      f"{FEP_ESTIMATORS + TI_ESTIMATORS}."
-                self.logger.error(msg)
-                raise ValueError(msg)
+        if estimators is not None:
+            if isinstance(estimators, str):
+                estimators = [estimators, ]
+            for estimator in estimators:
+                if estimator in FEP_ESTIMATORS:
+                    use_FEP = True
+                elif estimator in TI_ESTIMATORS:
+                    use_TI = True
+                else:
+                    msg = f"Estimator {estimator} is not supported. Choose one from " \
+                          f"{FEP_ESTIMATORS + TI_ESTIMATORS}."
+                    self.logger.error(msg)
+                    raise ValueError(msg)
 
         self.read(use_FEP, use_TI)
 

--- a/src/alchemlyb/workflows/abfe.py
+++ b/src/alchemlyb/workflows/abfe.py
@@ -111,6 +111,9 @@ class ABFE(WorkflowBase):
         dHdl_list : list
             A list of :class:`pandas.DataFrame` of dHdl.
         '''
+        self.u_nk_sample_list = None
+        self.dHdl_sample_list = None
+
         u_nk_list = []
         dHdl_list = []
         for file in self.file_list:
@@ -154,11 +157,14 @@ class ABFE(WorkflowBase):
                                         'time').index.values[0]))
         elif read_dHdl:
             self.logger.info('Sort files according to the dHdl.')
-            column_names = dHdl_list[0].columns.values.tolist()
             index_list = sorted(range(len(self.file_list)),
-                                key=lambda x: column_names.index(
+                                key=lambda x:
                                     dHdl_list[x].reset_index(
-                                        'time').index.values[0]))
+                                        'time').index.values[0])
+        else:
+            self.u_nk_list = []
+            self.dHdl_list = []
+            return
 
         self.file_list = [self.file_list[i] for i in index_list]
         self.logger.info("Sorted file list: \n%s", '\n'.join(self.file_list))
@@ -171,8 +177,7 @@ class ABFE(WorkflowBase):
             self.dHdl_list = [dHdl_list[i] for i in index_list]
         else:
             self.dHdl_list = []
-        self.u_nk_sample_list = None
-        self.dHdl_sample_list = None
+
 
     def run(self, skiptime=0, uncorr='dhdl', threshold=50,
             estimators=('MBAR', 'BAR', 'TI'), overlap='O_MBAR.pdf',


### PR DESCRIPTION
If not explicitly set, AMBER will not generate the dHdl file. (I don't know if the u_nk will be written by default but I got a complain that workflow cannot be used to process their amber output, which doesn't have dhdl data). Currently, the ABFE workflow will attempt to read both dHdl and u_nk. This PR will make it such that if no TI estimator is chosen, the workflow will not attempt to read the dHdl.

I have also removed the ignore_warnings in the read file stage as maintaining it and having it to be clever enough to solve all the dumb user issues seems to be too much.
