### PR TITLE
AMBER parser now compare user-provided T with what's read from AMBER files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,9 @@ Enhancements
 Fixes
   - documented conda installation (available since 0.6.0) (#192)
   - AMBER parsers now use 'ntpr' information to read time properly (#221)
+  - AMBER parsers now skip the reading of averages (#226)
+  - AMBER parsers now check if the T provided by the user is the same
+    at which the simulations were run (#225)
 
 
 07/22/2022 xiki-tempula, IAlibay, dotsdl, orbeckst, ptmerz

--- a/CHANGES
+++ b/CHANGES
@@ -35,10 +35,10 @@ Enhancements
 
 Fixes
   - documented conda installation (available since 0.6.0) (#192)
-  - AMBER parsers now use 'ntpr' information to read time properly (#221)
-  - AMBER parsers now skip the reading of averages (#226)
+  - AMBER parsers now use 'ntpr' information to read time properly (issue #221, PR #224)
+  - AMBER parsers now skip the reading of averages (issue #226, PR #230)
   - AMBER parsers now check if the T provided by the user is the same
-    at which the simulations were run (#225)
+    at which the simulations were run (issue #225, PR #232)
 
 
 07/22/2022 xiki-tempula, IAlibay, dotsdl, orbeckst, ptmerz

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -200,10 +200,8 @@ def file_validation(outfile):
                                           ['nstlim', 'dt'])
         T, = secp.extract_section('temperature regulation:', '^$',
                                   ['temp0'])
-        if not T:
-            logger.error('Non-constant temperature MD not '
-                         'currently supported.')
-            invalid = True
+        if not T:  # NOTE maybe we could remove this check completely
+            logger.warning('WARNING: no valid "temp0" record found in file')
         clambda, = secp.extract_section('^Free energy options:', '^$',
                                         ['clambda'], '^---')
         if clambda is None:
@@ -282,6 +280,12 @@ def extract_u_nk(outfile, T):
     file_datum = file_validation(outfile)
     if not file_validation(outfile):   # pragma: no cover
         return None
+
+    if not np.isclose(T, file_datum.T):
+        logger.warning(
+            'WARNING: the temperature read from the input file (%.2f K),'
+            ' is different from the temperature passed as parameter (%.2f K)' % (file_datum.T, T))
+
     if not file_datum.have_mbar:
         raise Exception('ERROR: No MBAR energies found! Cannot parse file.')
     with SectionParser(outfile) as secp:
@@ -342,6 +346,12 @@ def extract_dHdl(outfile, T):
     file_datum = file_validation(outfile)
     if not file_validation(outfile):
         return None
+
+    if not np.isclose(T, file_datum.T):
+        logger.warning(
+            'WARNING: the temperature read from the input file (%.2f K),'
+            ' is different from the temperature passed as parameter (%.2f K)' % (file_datum.T, T))
+
     finished = False
     comps = []
     with SectionParser(outfile) as secp:

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -282,9 +282,10 @@ def extract_u_nk(outfile, T):
         return None
 
     if not np.isclose(T, file_datum.T, atol=0.01):
-        logger.warning(
-            'WARNING: the temperature read from the input file (%.2f K),'
-            ' is different from the temperature passed as parameter (%.2f K)' % (file_datum.T, T))
+        msg = f'The temperature read from the input file ({file_datum.T:.2f} K)'
+        msg += f' is different from the temperature passed as parameter ({T:.2f} K)'
+        logger.error(msg)
+        raise ValueError(msg)
 
     if not file_datum.have_mbar:
         raise Exception('ERROR: No MBAR energies found! Cannot parse file.')
@@ -348,9 +349,10 @@ def extract_dHdl(outfile, T):
         return None
 
     if not np.isclose(T, file_datum.T, atol=0.01):
-        logger.warning(
-            'WARNING: the temperature read from the input file (%.2f K),'
-            ' is different from the temperature passed as parameter (%.2f K)' % (file_datum.T, T))
+        msg = f'The temperature read from the input file ({file_datum.T:.2f} K)'
+        msg += f' is different from the temperature passed as parameter ({T:.2f} K)'
+        logger.error(msg)
+        raise ValueError(msg)
 
     finished = False
     comps = []
@@ -383,7 +385,7 @@ def extract_dHdl(outfile, T):
     if not nensec:  # pragma: no cover
         logger.warning('WARNING: File %s does not contain any DV/DL data',
                         outfile)
-    logger.info(f'{nensec} DV/DL data points')
+    logger.info(f'Read {nensec} DV/DL data points')
     # at this step we get info stored in the FEData object for a given amber out file
     file_datum.component_gradients.extend(comps)
     # convert file_datum to the pandas format to make it identical to alchemlyb output format

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -281,7 +281,7 @@ def extract_u_nk(outfile, T):
     if not file_validation(outfile):   # pragma: no cover
         return None
 
-    if not np.isclose(T, file_datum.T):
+    if not np.isclose(T, file_datum.T, atol=0.01):
         logger.warning(
             'WARNING: the temperature read from the input file (%.2f K),'
             ' is different from the temperature passed as parameter (%.2f K)' % (file_datum.T, T))
@@ -347,7 +347,7 @@ def extract_dHdl(outfile, T):
     if not file_validation(outfile):
         return None
 
-    if not np.isclose(T, file_datum.T):
+    if not np.isclose(T, file_datum.T, atol=0.01):
         logger.warning(
             'WARNING: the temperature read from the input file (%.2f K),'
             ' is different from the temperature passed as parameter (%.2f K)' % (file_datum.T, T))

--- a/src/alchemlyb/tests/parsing/test_amber.py
+++ b/src/alchemlyb/tests/parsing/test_amber.py
@@ -76,9 +76,10 @@ def test_wrong_T_should_raise_warning_in_extract_dHdl(single_dHdl, T=300.0):
     Test if calling extract_dHdl with differnt T from what's
     read from the AMBER file gives a warning
     """
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ValueError,
+        match="is different from the temperature passed as parameter"):
         _ = extract_dHdl(single_dHdl, T=T)
-    assert "is different from the temperature passed as parameter" in str(exc_info.value)
 
 
 def test_wrong_T_should_raise_warning_in_extract_u_nk(single_u_nk, T=300.0):
@@ -86,9 +87,10 @@ def test_wrong_T_should_raise_warning_in_extract_u_nk(single_u_nk, T=300.0):
     Test if calling extract_u_nk with differnt T from what's
     read from the AMBER file gives a warning
     """
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ValueError,
+        match="is different from the temperature passed as parameter"):
         _ = extract_u_nk(single_u_nk, T=T)
-    assert "is different from the temperature passed as parameter" in str(exc_info.value)
 
 
 @pytest.mark.parametrize("filename",

--- a/src/alchemlyb/tests/parsing/test_amber.py
+++ b/src/alchemlyb/tests/parsing/test_amber.py
@@ -2,6 +2,7 @@
 
 """
 import pytest
+import logging
 from numpy.testing import assert_allclose
 
 from alchemlyb.parsing.amber import extract_dHdl
@@ -53,21 +54,41 @@ def test_invalidfiles(invalid_file):
 
 def test_dHdl_invalidfiles(invalid_file):
     """Test if we catch possible parsing errors in invalid files"""
-    assert extract_dHdl(invalid_file, T=300) is None
+    assert extract_dHdl(invalid_file, T=298.0) is None
 
 
 def test_dHdl_time_reading(single_dHdl, first_time=22.0, last_time=1020.0):
     """Test if time information is read correctly when extracting dHdl"""
-    dHdl = extract_dHdl(single_dHdl, T=300)
+    dHdl = extract_dHdl(single_dHdl, T=298.0)
     assert_allclose(dHdl.index.values[0][0], first_time)
     assert_allclose(dHdl.index.values[-1][0], last_time)
 
 
 def test_u_nk_time_reading(single_u_nk, first_time=22.0, last_time=1020.0):
     """Test if time information is read correctly when extracting u_nk"""
-    u_nk = extract_u_nk(single_u_nk, T=300)
+    u_nk = extract_u_nk(single_u_nk, T=298.0)
     assert_allclose(u_nk.index.values[0][0], first_time)
     assert_allclose(u_nk.index.values[-1][0], last_time)
+
+
+def test_wrong_T_should_raise_warning_in_extract_dHdl(caplog, single_dHdl, T=300.0):
+    """
+    Test if calling extract_dHdl with differnt T from what's
+    read from the AMBER file gives a warning
+    """
+    caplog.set_level(logging.WARNING)
+    _ = extract_dHdl(single_dHdl, T=T)
+    assert "the temperature read from the input file" in caplog.text
+
+
+def test_wrong_T_should_raise_warning_in_extract_u_nk(caplog, single_u_nk, T=300.0):
+    """
+    Test if calling extract_u_nk with differnt T from what's
+    read from the AMBER file gives a warning
+    """
+    caplog.set_level(logging.WARNING)
+    _ = extract_u_nk(single_u_nk, T=T)
+    assert "the temperature read from the input file" in caplog.text
 
 
 @pytest.mark.parametrize("filename",
@@ -78,7 +99,7 @@ def test_dHdl(filename,
               names=('time', 'lambdas'),
               shape=(500, 1)):
     """Test that dHdl has the correct form when extracted from files."""
-    dHdl = extract_dHdl(filename, T=300)
+    dHdl = extract_dHdl(filename, T=298.0)
 
     assert dHdl.index.names == names
     assert dHdl.shape == shape
@@ -91,7 +112,7 @@ def test_dHdl(filename,
 def test_u_nk(mbar_filename,
               names=('time', 'lambdas')):
     """Test the u_nk has the correct form when extracted from files"""
-    u_nk = extract_u_nk(mbar_filename, T=300)
+    u_nk = extract_u_nk(mbar_filename, T=298.0)
 
     assert u_nk.index.names == names
 
@@ -104,7 +125,7 @@ def test_u_nk_improper(improper_filename,
                        names=('time', 'lambdas')):
     """Test the u_nk has the correct form when extracted from files"""
     try:
-        u_nk = extract_u_nk(improper_filename, T=300)
+        u_nk = extract_u_nk(improper_filename, T=298.0)
         assert u_nk.index.names == names
     except Exception:
         assert '0.5626' in improper_filename

--- a/src/alchemlyb/tests/parsing/test_amber.py
+++ b/src/alchemlyb/tests/parsing/test_amber.py
@@ -71,24 +71,24 @@ def test_u_nk_time_reading(single_u_nk, first_time=22.0, last_time=1020.0):
     assert_allclose(u_nk.index.values[-1][0], last_time)
 
 
-def test_wrong_T_should_raise_warning_in_extract_dHdl(caplog, single_dHdl, T=300.0):
+def test_wrong_T_should_raise_warning_in_extract_dHdl(single_dHdl, T=300.0):
     """
     Test if calling extract_dHdl with differnt T from what's
     read from the AMBER file gives a warning
     """
-    caplog.set_level(logging.WARNING)
-    _ = extract_dHdl(single_dHdl, T=T)
-    assert "the temperature read from the input file" in caplog.text
+    with pytest.raises(ValueError) as exc_info:
+        _ = extract_dHdl(single_dHdl, T=T)
+    assert "is different from the temperature passed as parameter" in str(exc_info.value)
 
 
-def test_wrong_T_should_raise_warning_in_extract_u_nk(caplog, single_u_nk, T=300.0):
+def test_wrong_T_should_raise_warning_in_extract_u_nk(single_u_nk, T=300.0):
     """
     Test if calling extract_u_nk with differnt T from what's
     read from the AMBER file gives a warning
     """
-    caplog.set_level(logging.WARNING)
-    _ = extract_u_nk(single_u_nk, T=T)
-    assert "the temperature read from the input file" in caplog.text
+    with pytest.raises(ValueError) as exc_info:
+        _ = extract_u_nk(single_u_nk, T=T)
+    assert "is different from the temperature passed as parameter" in str(exc_info.value)
 
 
 @pytest.mark.parametrize("filename",

--- a/src/alchemlyb/tests/test_fep_estimators.py
+++ b/src/alchemlyb/tests/test_fep_estimators.py
@@ -84,7 +84,7 @@ def gmx_water_particle_without_energy():
 def amber_bace_example_complex_vdw():
     dataset = alchemtest.amber.load_bace_example()
 
-    u_nk = alchemlyb.concat([amber.extract_u_nk(filename, T=300)
+    u_nk = alchemlyb.concat([amber.extract_u_nk(filename, T=298.0)
                       for filename in dataset['data']['complex']['vdw']])
     return u_nk
 

--- a/src/alchemlyb/tests/test_fep_estimators.py
+++ b/src/alchemlyb/tests/test_fep_estimators.py
@@ -157,7 +157,7 @@ class TestMBAR(FEPestimatorMixin):
                             (gmx_water_particle_with_total_energy, -11.680, 0.083655),
                             (gmx_water_particle_with_potential_energy, -11.675, 0.083589),
                             (gmx_water_particle_without_energy, -11.654, 0.083415),
-                            (amber_bace_example_complex_vdw, 2.40200, 0.0618453),
+                            (amber_bace_example_complex_vdw, 2.41149, 0.0620658),
                             (gomc_benzene_u_nk, -0.79994, 0.091579),
                     ])
     def X_delta_f(self, request):

--- a/src/alchemlyb/tests/test_fep_estimators.py
+++ b/src/alchemlyb/tests/test_fep_estimators.py
@@ -208,7 +208,7 @@ class TestBAR(FEPestimatorMixin):
                               (gmx_water_particle_with_total_energy, -11.675, 0.065055),
                               (gmx_water_particle_with_potential_energy, -11.724, 0.064964),
                               (gmx_water_particle_without_energy, -11.660, 0.064914),
-                              (amber_bace_example_complex_vdw, 2.37846, 0.050899),
+                              (amber_bace_example_complex_vdw, 2.39294, 0.051192),
                               (namd_tyr2ala, 11.0044, 0.10235),
                               (namd_idws, 0.221147, 0.041003),
                               (namd_idws_restarted, 7.081127, 0.0344211),

--- a/src/alchemlyb/tests/test_ti_estimators.py
+++ b/src/alchemlyb/tests/test_ti_estimators.py
@@ -82,7 +82,7 @@ def gmx_water_particle_without_energy_dHdl():
 def amber_simplesolvated_charge_dHdl():
     dataset = alchemtest.amber.load_simplesolvated()
 
-    dHdl = alchemlyb.concat([amber.extract_dHdl(filename, T=300)
+    dHdl = alchemlyb.concat([amber.extract_dHdl(filename, T=298.0)
                       for filename in dataset['data']['charge']])
 
     return dHdl
@@ -90,7 +90,7 @@ def amber_simplesolvated_charge_dHdl():
 def amber_simplesolvated_vdw_dHdl():
     dataset = alchemtest.amber.load_simplesolvated()
 
-    dHdl = alchemlyb.concat([amber.extract_dHdl(filename, T=300)
+    dHdl = alchemlyb.concat([amber.extract_dHdl(filename, T=298.0)
                       for filename in dataset['data']['vdw']])
 
     return dHdl
@@ -121,7 +121,7 @@ class TestTI(TIestimatorMixin):
     """
     cls = TI
 
-    T = 300
+    T = 298.0
     kT_amber = amber.k_b * T
 
     @pytest.fixture(scope="class",

--- a/src/alchemlyb/tests/test_workflow_ABFE.py
+++ b/src/alchemlyb/tests/test_workflow_ABFE.py
@@ -361,7 +361,7 @@ class Test_automatic_amber():
             os.path.dirname(load_bace_example()['data']['complex']['vdw'][0]))
 
         workflow = ABFE(units='kcal/mol', software='AMBER', dir=dir,
-                        prefix='ti', suffix='bz2', T=310, outdirectory=str(
+                        prefix='ti', suffix='bz2', T=298.0, outdirectory=str(
                 outdir))
         workflow.read()
         workflow.estimate(estimators='TI')
@@ -375,4 +375,4 @@ class Test_automatic_amber():
 def test_no_parser():
     with pytest.raises(NotImplementedError):
         workflow = ABFE(units='kcal/mol', software='aaa',
-                        prefix='ti', suffix='bz2', T=310)
+                        prefix='ti', suffix='bz2', T=298.0)


### PR DESCRIPTION
This PR addresses issue #225, now:

- we require ```T``` in input for the parser
- we still read ```temp0``` from AMBER output
- the WARNING about non-constant T simulation is now a WARNING (the check could also be removed)
- the parser raises a WARNING if ```temp0 != T``` (two new tests now assert that)
- now the tests in ```test_amber.py``` use the correct  T=298.0
