### PR TITLE
replaced useless function "any_none()" with a check for "None in"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,7 @@ Fixes
   - AMBER parsers now check if the T provided by the user is the same
     at which the simulations were run (issue #225, PR #232)
   - changed how int/float are read from AMBER files (issue #229, PR #235)
+  - substitute the any_none() function with a check "if None in" in the AMBER parser (issue #236, PR #237)
 
 07/22/2022 xiki-tempula, IAlibay, dotsdl, orbeckst, ptmerz
 

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -45,16 +45,6 @@ DVDL_COMPS = ['BOND', 'ANGLE', 'DIHED', '1-4 NB', '1-4 EEL', 'VDWAALS',
 _FP_RE = r'[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?'
 
 
-def any_none(sequence):
-    """Check if any element of a sequence is None."""
-
-    for element in sequence:
-        if element is None:
-            return True
-
-    return False
-
-
 def _pre_gen(it, first):
     """A generator that returns first first if it exists."""
 
@@ -295,7 +285,7 @@ def extract_u_nk(outfile, T):
                 mbar = secp.extract_section('^MBAR', '^ ---', file_datum.mbar_lambdas,
                                             extra=line)
 
-                if any_none(mbar):
+                if None in mbar:
                     continue
 
                 E_ref = mbar[file_datum.mbar_lambda_idx]

--- a/src/alchemlyb/tests/parsing/test_amber.py
+++ b/src/alchemlyb/tests/parsing/test_amber.py
@@ -8,7 +8,6 @@ from numpy.testing import assert_allclose
 from alchemlyb.parsing.amber import extract_dHdl
 from alchemlyb.parsing.amber import extract_u_nk
 from alchemlyb.parsing.amber import file_validation
-from alchemlyb.parsing.amber import any_none
 from alchemtest.amber import load_simplesolvated
 from alchemtest.amber import load_invalidfiles
 from alchemtest.amber import load_bace_example
@@ -36,12 +35,6 @@ def fixture_single_u_nk():
 def fixture_single_dHdl():
     """return a single file to check u_unk parsing"""
     return load_simplesolvated().data['charge'][0]
-
-
-def test_any_none():
-    """Test the any None function to ensure if the None value will be caught"""
-    None_value_result = [150000, None, None, None, None, None, None, None, None]
-    assert any_none(None_value_result) is True
 
 
 def test_invalidfiles(invalid_file):


### PR DESCRIPTION
This PR removes the useless function `any_none()` which does the same work as an `if None in`, and the relative test is removed. 

This was suggested in issue #236.

I'm not introducing a check for `mbar==None`, maintaining the logic as before.
