### PR TITLE
Add extract description in docs

### DIFF
--- a/docs/parsing.rst
+++ b/docs/parsing.rst
@@ -14,6 +14,10 @@ Each submodule features at least two functions, namely:
   Extract reduced potentials, :math:`u_{nk}`, for each timestep of the sampled state and all neighboring states.
   Required input for :ref:`FEP-based estimators <estimators_fep>`.
 
+:func:`extract`
+  Extract both reduced potentials and the gradient of the Hamiltonian, :math:`u_{nk}` and :math:`\frac{dH}{d\lambda}`, in the form of a dictionary ``'dHdl': Series,  'u_nk': DataFrame``.
+  Required input for :ref:`FEP-based estimators <estimators_fep>` and :ref:`TI-based estimators <estimators_ti>`.
+
 These functions have a consistent interface across all submodules, often taking a single file as input and any additional parameters required for giving either ``dHdl`` or ``u_nk`` in standard form.
 
 Standard forms of raw data

--- a/src/alchemlyb/tests/parsing/test_namd.py
+++ b/src/alchemlyb/tests/parsing/test_namd.py
@@ -308,7 +308,7 @@ def test_extract():
 
     assert df_dict['u_nk'].index.names == ['time', 'fep-lambda']
     assert df_dict['u_nk'].shape == (30170, 11)
-    # assert df_dict['dHdl'] is None
+    assert 'dHdl' not in df_dict
 
 
 def test_u_nk_restarted_reversed_missing_window_header(tmp_path):


### PR DESCRIPTION
Just a couple of things that I forgot about:
- added the description of `extract` to the main `parsers` page in the documentation
- the test in test_namd.py now properly tests if 'dHdl' is not set when calling `extract`