### PR TITLE
Make the error optional for plot_convergence

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Enhancements
   - Add remove_burnin keyword to decorrelate_u_nk and decorrelate_dhdl (PR #218).
   - Add a base class for workflows (PR #188).
   - Add the ABFE workflow (PR #114).
+  - Add the keyword arg final_error to plot_convergence (#249)
 
 
 Fixes

--- a/src/alchemlyb/tests/test_visualisation.py
+++ b/src/alchemlyb/tests/test_visualisation.py
@@ -144,6 +144,7 @@ def test_plot_convergence_dataframe_noerr():
     ax = plot_convergence(data, final_error=2)
     assert isinstance(ax, matplotlib.axes.Axes)
     plt.close(ax.figure)
+
 def test_plot_convergence():
     bz = load_benzene().data
     data_list = [extract_u_nk(xvg, T=300) for xvg in bz['Coulomb']]

--- a/src/alchemlyb/tests/test_visualisation.py
+++ b/src/alchemlyb/tests/test_visualisation.py
@@ -135,6 +135,15 @@ def test_plot_convergence_dataframe():
     assert isinstance(ax, matplotlib.axes.Axes)
     plt.close(ax.figure)
 
+def test_plot_convergence_dataframe_noerr():
+    # Test the input from R_c
+    data = pd.DataFrame(data={'Forward': range(100),
+                              'Backward': range(100),
+                              'data_fraction': np.linspace(0,1,100)})
+    data.attrs = {'temperature': 300, 'energy_unit': 'kT'}
+    ax = plot_convergence(data, final_error=2)
+    assert isinstance(ax, matplotlib.axes.Axes)
+    plt.close(ax.figure)
 def test_plot_convergence():
     bz = load_benzene().data
     data_list = [extract_u_nk(xvg, T=300) for xvg in bz['Coulomb']]

--- a/src/alchemlyb/visualisation/convergence.py
+++ b/src/alchemlyb/visualisation/convergence.py
@@ -115,7 +115,7 @@ def plot_convergence(*data, units='kT', final_error=None, ax=None):
 
     xticks_spacing = len(r_ts) // 10 or 1
     xticks = r_ts[::xticks_spacing]
-    plt.xticks(xticks, fontsize=10)
+    plt.xticks(xticks, ['%.2f' % i for i in xticks], fontsize=10)
     plt.yticks(fontsize=10)
 
     ax.legend((line1[0], line2[0]), ('Forward', 'Reverse'), loc=9,
@@ -123,7 +123,6 @@ def plot_convergence(*data, units='kT', final_error=None, ax=None):
     ax.set_xlabel(r'Fraction of the simulation time', fontsize=16,
                   color='#151B54')
     ax.set_ylabel(r'$\Delta G$ ({})'.format(units), fontsize=16, color='#151B54')
-    plt.xticks(xticks, ['%.2f' % i for i in xticks])
     plt.tick_params(axis='x', color='#D2B9D3')
     plt.tick_params(axis='y', color='#D2B9D3')
     return ax

--- a/src/alchemlyb/visualisation/convergence.py
+++ b/src/alchemlyb/visualisation/convergence.py
@@ -23,7 +23,9 @@ def plot_convergence(*data, units='kT', final_error=None, ax=None):
     shape and can be used as input for the
     :func:`matplotlib.pyplot.errorbar`.
 
-    final_error is a float decides the width of the bar around the final value.
+   `final_error` is the error of the final value and is shown as the error band around the 
+   final value. It can be provided in case an estimate is available that is more appropriate
+   than the default, which is the error of the last value in `backward`.
 
     Parameters
     ----------

--- a/src/alchemlyb/visualisation/convergence.py
+++ b/src/alchemlyb/visualisation/convergence.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from ..postprocessors.units import get_unit_converter
 
-def plot_convergence(*data, units='kT', ax=None):
+def plot_convergence(*data, units='kT', final_error=None, ax=None):
     """Plot the forward and backward convergence.
 
     The input could be the result from
@@ -23,6 +23,8 @@ def plot_convergence(*data, units='kT', ax=None):
     shape and can be used as input for the
     :func:`matplotlib.pyplot.errorbar`.
 
+    final_error is a float decides the width of the bar around the final value.
+
     Parameters
     ----------
     data : Dataframe or 4 array_like objects
@@ -32,6 +34,9 @@ def plot_convergence(*data, units='kT', ax=None):
         `backward_error` see :ref:`plot_convergence <plot_convergence>`.
     units : str
         The unit of the estimate. See `Note` for a detailed explanation. Default: "kT"
+    final_error : float
+        The error of the final value in ``units``. If not given, takes the last
+        error in `backward_error`.
     ax : matplotlib.axes.Axes
         Matplotlib axes object where the plot will be drawn on. If ``ax=None``,
         a new axes will be generated.
@@ -53,6 +58,9 @@ def plot_convergence(*data, units='kT', ax=None):
     and changing it doesn't change the unit of the underlying variable.
 
 
+    .. versionchanged:: 1.0.0
+        Keyword arg final_error for plotting a horizontal error bar
+
     .. versionchanged:: 0.6.0
         data now takes in dataframe
 
@@ -61,9 +69,15 @@ def plot_convergence(*data, units='kT', ax=None):
     if len(data) == 1 and isinstance(data[0], pd.DataFrame):
         dataframe = get_unit_converter(units)(data[0])
         forward = dataframe['Forward'].to_numpy()
-        forward_error = dataframe['Forward_Error'].to_numpy()
+        if 'Forward_Error' in dataframe:
+            forward_error = dataframe['Forward_Error'].to_numpy()
+        else:
+            forward_error = np.zeros(len(forward))
         backward = dataframe['Backward'].to_numpy()
-        backward_error = dataframe['Backward_Error'].to_numpy()
+        if 'Backward_Error' in dataframe:
+            backward_error = dataframe['Backward_Error'].to_numpy()
+        else:
+            backward_error = np.zeros(len(backward))
     else:
         try:
             forward, forward_error, backward, backward_error = data
@@ -86,9 +100,12 @@ def plot_convergence(*data, units='kT', ax=None):
     f_ts = np.linspace(0, 1, len(forward) + 1)[1:]
     r_ts = np.linspace(0, 1, len(backward) + 1)[1:]
 
-    line0 = ax.fill_between([0, 1], backward[-1] - backward_error[-1],
-                            backward[-1] + backward_error[-1], color='#D2B9D3',
-                             zorder=1)
+    if final_error is None:
+        final_error = backward_error[-1]
+
+    line0 = ax.fill_between([0, 1], backward[-1] - final_error,
+                            backward[-1] + final_error, color='#D2B9D3',
+                            zorder=1)
     line1 = ax.errorbar(f_ts, forward, yerr=forward_error, color='#736AFF',
                         lw=3, zorder=2, marker='o',
                         mfc='w', mew=2.5, mec='#736AFF', ms=12,)
@@ -96,7 +113,9 @@ def plot_convergence(*data, units='kT', ax=None):
                         lw=3, zorder=3, marker='o',
                         mfc='w', mew=2.5, mec='#C11B17', ms=12, )
 
-    plt.xticks(r_ts[::2], fontsize=10)
+    xticks_spacing = len(r_ts) // 10 or 1
+    xticks = r_ts[::xticks_spacing]
+    plt.xticks(xticks, fontsize=10)
     plt.yticks(fontsize=10)
 
     ax.legend((line1[0], line2[0]), ('Forward', 'Reverse'), loc=9,
@@ -104,7 +123,7 @@ def plot_convergence(*data, units='kT', ax=None):
     ax.set_xlabel(r'Fraction of the simulation time', fontsize=16,
                   color='#151B54')
     ax.set_ylabel(r'$\Delta G$ ({})'.format(units), fontsize=16, color='#151B54')
-    plt.xticks(f_ts, ['%.2f' % i for i in f_ts])
+    plt.xticks(xticks, ['%.2f' % i for i in xticks])
     plt.tick_params(axis='x', color='#D2B9D3')
     plt.tick_params(axis='y', color='#D2B9D3')
     return ax


### PR DESCRIPTION
Currently the plot_convergence demand the input dataframe to have forward_error and backward_error. This PR makes these two input optional. So when these two columns are not present in the input dataframe, no errorbar will be plotted.

I have not touched the array input as we will deprecate them in #247.

A final_error keyword has been added to deal with the case where error is not provided and the user wish to plot the error of the final estimate.

Fix the issue where when too many data points are included, the x-axis will be too crowded.