### PR TITLE
Raise except instead of continuing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,8 +18,8 @@ The rules for this file:
   * 1.0.0
 
 Changes
-  - Now AMBER parser raises an exception when an inconsinstency in 
-    the input file is found, instead of ignoring the file (PR #)
+  - Now AMBER parser raises an exception when an inconsinstency in the input
+    file is found, instead of ignoring the file (issues #227 #238, PR #256)
   - Now AMBER parser raises an exception when an inconsinstency in 
     MBAR data is found (PR #253)
   - Drop support for py3.7 (Issue #179, PR #214)

--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ The rules for this file:
 
 Changes
   - Now AMBER parser raises an exception when an inconsinstency in 
+    the input file is found, instead of ignoring the file (PR #)
+  - Now AMBER parser raises an exception when an inconsinstency in 
     MBAR data is found (PR #253)
   - Drop support for py3.7 (Issue #179, PR #214)
   - forward_backward_convergence will use AutoMBAR as backend when `MBAR` is

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -178,7 +178,7 @@ def file_validation(outfile):
 
     Returns
     -------
-    file_datum : `:obj:~FEData`
+    `:class:~FEData`
         FEData object populated with data from the parsed AMBER output file.
 
     """
@@ -233,11 +233,11 @@ def file_validation(outfile):
                 mbar_nlambda = len(mbar_lambdas)
                 if mbar_nlambda != mbar_states:
                     logger.error(
-                        'The number of lambda windows read (%s)'
+                        'the number of lambda windows read (%s)'
                         'is different from what expected (%d)',
                         ','.join(mbar_lambdas), mbar_states)
                     raise ValueError(
-                        f'The number of lambda windows read ({mbar_nlambda})'
+                        f'the number of lambda windows read ({mbar_nlambda})'
                         f' is different from what expected ({mbar_states})')
                 mbar_lambda_idx = mbar_lambdas.index(clambda_str)
                 file_datum.mbar_lambda_idx = mbar_lambda_idx
@@ -246,13 +246,13 @@ def file_validation(outfile):
                     file_datum.mbar_energies.append([])
 
         if not secp.skip_after('^   3.  ATOMIC '):
-            logger.error('No "ATOMIC" section found in the file.')
-            raise ValueError(f'No "ATOMIC" section found in file {outfile}')
+            logger.error('no "ATOMIC" section found in the file.')
+            raise ValueError(f'no "ATOMIC" section found in file {outfile}')
 
         t0, = secp.extract_section('^ begin time', '^$', ['coords'])
         if not secp.skip_after('^   4.  RESULTS'):
-            logger.error('No "RESULTS" section found in the file.')
-            raise ValueError(f'No "RESULTS" section found in file {outfile}')
+            logger.error('no "RESULTS" section found in the file.')
+            raise ValueError(f'no "RESULTS" section found in file {outfile}')
 
 
     file_datum.clambda = clambda

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -186,22 +186,30 @@ def file_validation(outfile):
     file_datum = FEData()
     with SectionParser(outfile) as secp:
         line = secp.skip_lines(5)
+
         if not line:
-            raise ValueError(f'File {outfile} does not contain any useful data')
+            logger.error("the file does not contain any data, it's empty.")
+            raise ValueError(f'file {outfile} does not contain any data.')
+
         if not secp.skip_after('^   2.  CONTROL  DATA  FOR  THE  RUN'):
-            raise ValueError(f'No "CONTROL DATA" found in file {outfile}')
+            logger.error('no "CONTROL DATA" section found in the file.')
+            raise ValueError(f'no "CONTROL DATA" section found in file {outfile}')
+
         ntpr, = secp.extract_section('^Nature and format of output:', '^$',
                                      ['ntpr'])
         nstlim, dt = secp.extract_section('Molecular dynamics:', '^$',
                                           ['nstlim', 'dt'])
         T, = secp.extract_section('temperature regulation:', '^$',
                                   ['temp0'])
-        if not T:  # NOTE maybe we could remove this check completely
-            logger.warning('WARNING: no valid "temp0" record found in file')
+        if not T:
+            logger.error('no valid "temp0" record found in file.')
+            raise ValueError(f'no valid "temp0" record found in file {outfile}')
+
         clambda, = secp.extract_section('^Free energy options:', '^$',
                                         ['clambda'], '^---')
         if clambda is None:
-            raise ValueError(f'No free energy section found in file {outfile}')
+            logger.error('no free energy section found in file, "clambda" was None.')
+            raise ValueError(f'no free energy section found in file {outfile}')
 
         mbar_ndata = 0
         have_mbar, mbar_ndata, mbar_states = secp.extract_section('^FEP MBAR options:',
@@ -238,10 +246,12 @@ def file_validation(outfile):
                     file_datum.mbar_energies.append([])
 
         if not secp.skip_after('^   3.  ATOMIC '):
+            logger.error('No "ATOMIC" section found in the file.')
             raise ValueError(f'No "ATOMIC" section found in file {outfile}')
 
         t0, = secp.extract_section('^ begin time', '^$', ['coords'])
         if not secp.skip_after('^   4.  RESULTS'):
+            logger.error('No "RESULTS" section found in the file.')
             raise ValueError(f'No "RESULTS" section found in file {outfile}')
 
 

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -6,8 +6,8 @@ Some of the file parsing parts are adapted from
 .. _alchemical-analysis: https://github.com/MobleyLab/alchemical-analysis
 
 .. versionchanged:: 1.0.0
-    Now raises an exception when an invalid file is given to the parser
-    Now raises an exception when inconsistency in MBAR states/data is found
+    Now raises :exc:`ValueError` when an invalid file is given to the parser.
+    Now raises :exc:`ValueError` when inconsistency in MBAR states/data is found.
 
 """
 

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -89,8 +89,7 @@ class SectionParser():
                 break
         return Found_pattern
 
-    def extract_section(self, start, end, fields, limit=None, extra='',
-                        debug=False):
+    def extract_section(self, start, end, fields, limit=None, extra=''):
         """
         Extract data values (int, float) in fields from a section
         marked with start and end regexes.  Do not read further than
@@ -341,10 +340,10 @@ def extract(outfile, T):
         mbar_df = None
 
     if not nensec:
-        logger.warning('WARNING: File %s does not contain any dV/dl data' % outfile)
+        logger.warning('WARNING: File %s does not contain any dV/dl data', outfile)
         dHdl_df = None
     else:
-        logger.info('Read %s DV/DL data points in file %s' % (nensec, outfile))
+        logger.info('Read %s DV/DL data points in file %s', nensec, outfile)
         dHdl_df = convert_to_pandas(file_datum)
         dHdl_df['dHdl'] *= beta
 

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -208,7 +208,7 @@ def file_validation(outfile):
         clambda, = secp.extract_section('^Free energy options:', '^$',
                                         ['clambda'], '^---')
         if clambda is None:
-            logger.error('no free energy section found in file, "clambda" was None.')
+            logger.error('No free energy section found in file %s, "clambda" was None.', outfile)
             raise ValueError(f'no free energy section found in file {outfile}')
 
         mbar_ndata = 0

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -246,7 +246,7 @@ def file_validation(outfile):
                     file_datum.mbar_energies.append([])
 
         if not secp.skip_after('^   3.  ATOMIC '):
-            logger.error('no "ATOMIC" section found in the file.')
+            logger.error('No "ATOMIC" section found in the file %s.', outfile)
             raise ValueError(f'no "ATOMIC" section found in file {outfile}')
 
         t0, = secp.extract_section('^ begin time', '^$', ['coords'])

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -321,7 +321,7 @@ def extract(outfile, T):
                                             extra=line)
 
                 if None in mbar:
-                    msg = "WARNING, something strange parsing the following MBAR section."
+                    msg = "Something strange parsing the following MBAR section."
                     msg += "\nMaybe the mbar_lambda values are incorrect?"
                     logger.error("%s\n%s", msg, mbar)
                     raise ValueError(msg)

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -202,7 +202,7 @@ def file_validation(outfile):
         T, = secp.extract_section('temperature regulation:', '^$',
                                   ['temp0'])
         if not T:
-            logger.error('no valid "temp0" record found in file.')
+            logger.error('No valid "temp0" record found in file %s.', outfile)
             raise ValueError(f'no valid "temp0" record found in file {outfile}')
 
         clambda, = secp.extract_section('^Free energy options:', '^$',

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -192,7 +192,7 @@ def file_validation(outfile):
             raise ValueError(f'file {outfile} does not contain any data.')
 
         if not secp.skip_after('^   2.  CONTROL  DATA  FOR  THE  RUN'):
-            logger.error('no "CONTROL DATA" section found in the file.')
+            logger.error('No "CONTROL DATA" section found in file %s.', outfile)
             raise ValueError(f'no "CONTROL DATA" section found in file {outfile}')
 
         ntpr, = secp.extract_section('^Nature and format of output:', '^$',

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -251,7 +251,7 @@ def file_validation(outfile):
 
         t0, = secp.extract_section('^ begin time', '^$', ['coords'])
         if not secp.skip_after('^   4.  RESULTS'):
-            logger.error('no "RESULTS" section found in the file.')
+            logger.error('No "RESULTS" section found in the file %s.', outfile)
             raise ValueError(f'no "RESULTS" section found in file {outfile}')
 
 

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -1,4 +1,4 @@
-"""Parsers for extracting alchemical data from `Amber <http://ambermd.org>`_ output files.
+"""Parsers for extracting alchemical data from `AMBER <http://ambermd.org>`_ output files.
 
 Some of the file parsing parts are adapted from
 `alchemical-analysis`_.
@@ -167,7 +167,22 @@ class FEData():
 
 
 def file_validation(outfile):
-    """validate the energy output file """
+    """
+    Function that validate and parse an AMBER output file.
+    :exc:`ValueError` are risen if inconsinstencies in the input file are found.
+    
+    Parameters
+    ----------
+    outfile : str
+        Path to AMBER .out file to validate and extract data from.
+
+    Returns
+    -------
+    file_datum : `:obj:~FEData`
+        FEData object populated with data from the parsed AMBER output file.
+
+    """
+
     file_datum = FEData()
     with SectionParser(outfile) as secp:
         line = secp.skip_lines(5)
@@ -242,12 +257,12 @@ def file_validation(outfile):
 
 @_init_attrs_dict
 def extract(outfile, T):
-    """Return reduced potentials `u_nk` and gradients `dH/dl` from Amber outputfile.
+    """Return reduced potentials `u_nk` and gradients `dH/dl` from AMBER outputfile.
 
     Parameters
     ----------
     outfile : str
-        Path to Amber .out file to extract data from.
+        Path to AMBER .out file to extract data from.
     T : float
         Temperature in Kelvin at which the simulations were performed;
         needed to generated the reduced potential (in units of kT)
@@ -345,12 +360,12 @@ def extract(outfile, T):
 
 
 def extract_dHdl(outfile, T):
-    """Return gradients ``dH/dl`` from Amber TI outputfile.
+    """Return gradients `dH/dl` from AMBER TI outputfile.
 
     Parameters
     ----------
     outfile : str
-        Path to Amber .out file to extract data from.
+        Path to AMBER .out file to extract data from.
     T : float
         Temperature in Kelvin at which the simulations were performed
 
@@ -370,12 +385,12 @@ def extract_dHdl(outfile, T):
 
 
 def extract_u_nk(outfile, T):
-    """Return reduced potentials `u_nk` from Amber outputfile.
+    """Return reduced potentials `u_nk` from AMBER outputfile.
 
     Parameters
     ----------
     outfile : str
-        Path to Amber .out file to extract data from.
+        Path to AMBER .out file to extract data from.
     T : float
         Temperature in Kelvin at which the simulations were performed;
         needed to generated the reduced potential (in units of kT)

--- a/src/alchemlyb/parsing/amber.py
+++ b/src/alchemlyb/parsing/amber.py
@@ -188,7 +188,7 @@ def file_validation(outfile):
         line = secp.skip_lines(5)
 
         if not line:
-            logger.error("the file does not contain any data, it's empty.")
+            logger.error("The file %s does not contain any data, it's empty.", outfile)
             raise ValueError(f'file {outfile} does not contain any data.')
 
         if not secp.skip_after('^   2.  CONTROL  DATA  FOR  THE  RUN'):

--- a/src/alchemlyb/tests/parsing/test_amber.py
+++ b/src/alchemlyb/tests/parsing/test_amber.py
@@ -61,7 +61,7 @@ def test_no_atomic_section(caplog, testfiles):
     with pytest.raises(ValueError, match='no "ATOMIC" section found'):
         with caplog.at_level(logging.ERROR):
             _ = extract(str(filename), T=298.0)
-    assert 'no "ATOMIC" section found' in caplog.text
+    assert 'No "ATOMIC" section found' in caplog.text
 
 
 def test_no_control_data(caplog, testfiles):

--- a/src/alchemlyb/tests/parsing/test_amber.py
+++ b/src/alchemlyb/tests/parsing/test_amber.py
@@ -53,36 +53,32 @@ def test_unfinished_run(caplog, testfiles):
     assert "is a prematurely terminated run" in caplog.text
 
 
-def test_no_atomic_section(caplog, testfiles):
+def test_no_atomic_section(testfiles):
     """Test if we give a warning if there is no ATOMIC section"""
     filename = testfiles["no_atomic_section"][0]
-    with caplog.at_level(logging.WARNING):
+    with pytest.raises(ValueError, match='No "ATOMIC" section found'):
         _ = extract(str(filename), T=298.0)
-    assert "No ATOMIC section found" in caplog.text
 
 
-def test_no_control_data(caplog, testfiles):
+def test_no_control_data(testfiles):
     """Test if we give a warning if there is no CONTROL section"""
     filename = testfiles["no_control_data"][0]
-    with caplog.at_level(logging.WARNING):
+    with pytest.raises(ValueError, match='No "CONTROL DATA" found'):
         _ = extract(str(filename), T=298.0)
-    assert "No CONTROL DATA found" in caplog.text
 
 
-def test_no_free_energy_info(caplog, testfiles):
+def test_no_free_energy_info(testfiles):
     """Test if we give a warning if there is no free energy section"""
     filename = testfiles["no_free_energy_info"][0]
-    with caplog.at_level(logging.WARNING):
+    with pytest.raises(ValueError, match='No free energy section found'):
         _ = extract(str(filename), T=298.0)
-    assert "No free energy section found" in caplog.text
 
 
-def test_no_useful_data(caplog, testfiles):
+def test_no_useful_data(testfiles):
     """Test if we give a warning if there is no useful data"""
     filename = testfiles["no_useful_data"][0]
-    with caplog.at_level(logging.WARNING):
-        _ = extract(str(filename), T=298.0)
-    assert "File does not contain any useful data" in caplog.text
+    with pytest.raises(ValueError, match="does not contain any useful data"):
+         _ = extract(str(filename), T=298.0)
 
 
 def test_no_temp0_set(caplog, testfiles):
@@ -93,12 +89,11 @@ def test_no_temp0_set(caplog, testfiles):
     assert "WARNING: no valid \"temp0\" record found in file" in caplog.text
 
 
-def test_no_results_section(caplog, testfiles):
+def test_no_results_section(testfiles):
     """Test if we give a warning if there is no RESULTS section"""
     filename = testfiles["no_results_section"][0]
-    with caplog.at_level(logging.WARNING):
+    with pytest.raises(ValueError, match='No "RESULTS" section found'):
         _ = extract(str(filename), T=298.0)
-    assert "No RESULTS section found, ignoring" in caplog.text
 
 
 def test_long_and_wrong_number_MBAR(testfiles):

--- a/src/alchemlyb/tests/parsing/test_amber.py
+++ b/src/alchemlyb/tests/parsing/test_amber.py
@@ -85,7 +85,8 @@ def test_no_temp0_set(caplog, testfiles):
     """Test if we give a warning if there is no temp0 set"""
     filename = testfiles["no_temp0_set"][0]
     with caplog.at_level(logging.WARNING):
-        _ = extract(str(filename), T=298.0)
+        with pytest.raises(ValueError):
+            _ = extract(str(filename), T=298.0)
     assert "WARNING: no valid \"temp0\" record found in file" in caplog.text
 
 

--- a/src/alchemlyb/tests/parsing/test_amber.py
+++ b/src/alchemlyb/tests/parsing/test_amber.py
@@ -38,11 +38,13 @@ def test_no_dHdl_data_points(caplog, testfiles):
     assert "does not contain any dV/dl data" in caplog.text
 
 
-def test_None_in_mbar(testfiles):
+def test_None_in_mbar(caplog, testfiles):
     """Test if we deal with an incorrect MBAR section"""
     filename = testfiles["none_in_mbar"][0]
     with pytest.raises(ValueError, match="strange parsing the following MBAR section"):
-        _ = extract(str(filename), T=298.0)
+        with caplog.at_level(logging.ERROR):
+            _ = extract(str(filename), T=298.0)
+    assert "strange parsing the following MBAR section" in caplog.text
 
 
 def test_unfinished_run(caplog, testfiles):
@@ -53,58 +55,70 @@ def test_unfinished_run(caplog, testfiles):
     assert "is a prematurely terminated run" in caplog.text
 
 
-def test_no_atomic_section(testfiles):
-    """Test if we give a warning if there is no ATOMIC section"""
+def test_no_atomic_section(caplog, testfiles):
+    """Test if raise an exception if there is no ATOMIC section"""
     filename = testfiles["no_atomic_section"][0]
-    with pytest.raises(ValueError, match='No "ATOMIC" section found'):
-        _ = extract(str(filename), T=298.0)
+    with pytest.raises(ValueError, match='no "ATOMIC" section found'):
+        with caplog.at_level(logging.ERROR):
+            _ = extract(str(filename), T=298.0)
+    assert 'no "ATOMIC" section found' in caplog.text
 
 
-def test_no_control_data(testfiles):
-    """Test if we give a warning if there is no CONTROL section"""
+def test_no_control_data(caplog, testfiles):
+    """Test if we raise an exception if there is no CONTROL section"""
     filename = testfiles["no_control_data"][0]
-    with pytest.raises(ValueError, match='No "CONTROL DATA" found'):
-        _ = extract(str(filename), T=298.0)
+    with pytest.raises(ValueError, match='no "CONTROL DATA" section found'):
+        with caplog.at_level(logging.ERROR):
+            _ = extract(str(filename), T=298.0)
+    assert 'no "CONTROL DATA" section found' in caplog.text
 
 
-def test_no_free_energy_info(testfiles):
-    """Test if we give a warning if there is no free energy section"""
+def test_no_free_energy_info(caplog, testfiles):
+    """Test if we raise an exception if there is no free energy section"""
     filename = testfiles["no_free_energy_info"][0]
-    with pytest.raises(ValueError, match='No free energy section found'):
-        _ = extract(str(filename), T=298.0)
+    with pytest.raises(ValueError, match='no free energy section found'):
+        with caplog.at_level(logging.ERROR):
+            _ = extract(str(filename), T=298.0)
+    assert 'no free energy section found' in caplog.text
 
 
-def test_no_useful_data(testfiles):
-    """Test if we give a warning if there is no useful data"""
+def test_no_useful_data(caplog, testfiles):
+    """Test if we raise an exception if there is no data"""
     filename = testfiles["no_useful_data"][0]
-    with pytest.raises(ValueError, match="does not contain any useful data"):
-         _ = extract(str(filename), T=298.0)
+    with pytest.raises(ValueError, match="does not contain any data"):
+        with caplog.at_level(logging.ERROR):
+            _ = extract(str(filename), T=298.0)
+    assert 'the file does not contain any data' in caplog.text
 
 
 def test_no_temp0_set(caplog, testfiles):
-    """Test if we give a warning if there is no temp0 set"""
+    """Test if we raise an exception if there is no temp0 set"""
     filename = testfiles["no_temp0_set"][0]
-    with caplog.at_level(logging.WARNING):
-        with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='no valid "temp0" record found'):
+        with caplog.at_level(logging.ERROR):
             _ = extract(str(filename), T=298.0)
-    assert "WARNING: no valid \"temp0\" record found in file" in caplog.text
+    assert 'no valid "temp0" record found' in caplog.text
 
 
-def test_no_results_section(testfiles):
-    """Test if we give a warning if there is no RESULTS section"""
+def test_no_results_section(caplog, testfiles):
+    """Test if we raise an exception if there is no RESULTS section"""
     filename = testfiles["no_results_section"][0]
-    with pytest.raises(ValueError, match='No "RESULTS" section found'):
-        _ = extract(str(filename), T=298.0)
+    with pytest.raises(ValueError, match='no "RESULTS" section found'):
+        with caplog.at_level(logging.ERROR):
+            _ = extract(str(filename), T=298.0)
+    assert 'no "RESULTS" section found' in caplog.text
 
 
-def test_long_and_wrong_number_MBAR(testfiles):
+def test_long_and_wrong_number_MBAR(caplog, testfiles):
     """
     Test if we have a high number of MBAR states, and also a different
     number of MBAR states than expected
     """
     filename = testfiles["high_and_wrong_number_of_mbar_windows"][0]
-    with pytest.raises(ValueError, match="The number of lambda windows read"):
-        _ = extract_u_nk(str(filename), T=300.0)
+    with pytest.raises(ValueError, match="the number of lambda windows read"):
+        with caplog.at_level(logging.ERROR):
+            _ = extract_u_nk(str(filename), T=300.0)
+    assert 'the number of lambda windows read' in caplog.text
 
 
 ##################################################################################

--- a/src/alchemlyb/tests/parsing/test_amber.py
+++ b/src/alchemlyb/tests/parsing/test_amber.py
@@ -70,7 +70,7 @@ def test_no_control_data(caplog, testfiles):
     with pytest.raises(ValueError, match='no "CONTROL DATA" section found'):
         with caplog.at_level(logging.ERROR):
             _ = extract(str(filename), T=298.0)
-    assert 'no "CONTROL DATA" section found' in caplog.text
+    assert 'No "CONTROL DATA" section found' in caplog.text
 
 
 def test_no_free_energy_info(caplog, testfiles):
@@ -79,7 +79,7 @@ def test_no_free_energy_info(caplog, testfiles):
     with pytest.raises(ValueError, match='no free energy section found'):
         with caplog.at_level(logging.ERROR):
             _ = extract(str(filename), T=298.0)
-    assert 'no free energy section found' in caplog.text
+    assert 'No free energy section found' in caplog.text
 
 
 def test_no_useful_data(caplog, testfiles):
@@ -88,7 +88,7 @@ def test_no_useful_data(caplog, testfiles):
     with pytest.raises(ValueError, match="does not contain any data"):
         with caplog.at_level(logging.ERROR):
             _ = extract(str(filename), T=298.0)
-    assert 'the file does not contain any data' in caplog.text
+    assert 'does not contain any data' in caplog.text
 
 
 def test_no_temp0_set(caplog, testfiles):
@@ -97,7 +97,7 @@ def test_no_temp0_set(caplog, testfiles):
     with pytest.raises(ValueError, match='no valid "temp0" record found'):
         with caplog.at_level(logging.ERROR):
             _ = extract(str(filename), T=298.0)
-    assert 'no valid "temp0" record found' in caplog.text
+    assert 'No valid "temp0" record found' in caplog.text
 
 
 def test_no_results_section(caplog, testfiles):
@@ -106,7 +106,7 @@ def test_no_results_section(caplog, testfiles):
     with pytest.raises(ValueError, match='no "RESULTS" section found'):
         with caplog.at_level(logging.ERROR):
             _ = extract(str(filename), T=298.0)
-    assert 'no "RESULTS" section found' in caplog.text
+    assert 'No "RESULTS" section found' in caplog.text
 
 
 def test_long_and_wrong_number_MBAR(caplog, testfiles):


### PR DESCRIPTION
Now `file_validation` will rise `ValueError` exceptions when errors/inconsistencies in the file are found, instead of just ignoring the problem. The tests are updated, but I found an error in a test file, which I addressed in a recent PR (until the alchemtest PR is accepted this PR will not have 100% success on the tests).