### PR TITLE
temporarily disable pytest-xdist

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest -v -n 2 --cov=alchemlyb --cov-report=xml --color=yes src/alchemlyb/tests
+        pytest -v --cov=alchemlyb --cov-report=xml --color=yes src/alchemlyb/tests
       env:
         MPLBACKEND: agg
 


### PR DESCRIPTION
- fix #257 
- temporary fix (reverse once pytest-xdist works again)