### PR TITLE
Default the plotting unit to None

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ The rules for this file:
   * 1.0.0
 
 Changes
+  - Default the units in plot_dF_state, plot_convergence and plot_ti_dhdl to
+    None. Remove the array input for plot_convergence (issue #247, PR #260).
   - Now AMBER parser raises an exception when an inconsinstency in the input
     file is found, instead of ignoring the file (issues #227 #238, PR #256)
   - Now AMBER parser raises an exception when an inconsinstency in 

--- a/src/alchemlyb/tests/test_visualisation.py
+++ b/src/alchemlyb/tests/test_visualisation.py
@@ -166,7 +166,12 @@ def test_plot_convergence():
         backward.append(estimate.delta_f_.iloc[0,-1])
         backward_error.append(estimate.d_delta_f_.iloc[0,-1])
 
-    ax = plot_convergence(forward, forward_error, backward, backward_error)
+    df = pd.DataFrame(data={'Forward': forward,
+                            'Forward_Error': forward_error,
+                            'Backward': backward,
+                            'Backward_Error': backward_error})
+    df.attrs = estimate.delta_f_.attrs
+    ax = plot_convergence(df)
     assert isinstance(ax, matplotlib.axes.Axes)
     plt.close(ax.figure)
 

--- a/src/alchemlyb/tests/test_visualisation.py
+++ b/src/alchemlyb/tests/test_visualisation.py
@@ -190,18 +190,19 @@ class Test_Units():
 
         return ti, mbar
 
-    def test_plot_dF_state_kT(self, estimaters):
-        fig = plot_dF_state(estimaters, units='kT')
-        assert isinstance(fig, matplotlib.figure.Figure)
-        plt.close(fig)
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def convergence():
+        df = pd.DataFrame(data={'Forward': range(10),
+                                'Forward_Error': range(10),
+                                'Backward': range(10),
+                                'Backward_Error': range(10)})
+        df.attrs = {'temperature': 300, 'energy_unit': 'kT'}
+        return df
 
-    def test_plot_dF_state_kJ(self, estimaters):
-        fig = plot_dF_state(estimaters, units='kJ/mol')
-        assert isinstance(fig, matplotlib.figure.Figure)
-        plt.close(fig)
-
-    def test_plot_dF_state_kcal(self, estimaters):
-        fig = plot_dF_state(estimaters, units='kcal/mol')
+    @pytest.mark.parametrize('units', [None, 'kT', 'kJ/mol', 'kcal/mol'])
+    def test_plot_dF_state(self, estimaters, units):
+        fig = plot_dF_state(estimaters, units=units)
         assert isinstance(fig, matplotlib.figure.Figure)
         plt.close(fig)
 
@@ -209,21 +210,10 @@ class Test_Units():
         with pytest.raises(ValueError):
             fig = plot_dF_state(estimaters, units='ddd')
 
-    def test_plot_ti_dhdl_kT(self, estimaters):
+    @pytest.mark.parametrize('units', [None, 'kT', 'kJ/mol', 'kcal/mol'])
+    def test_plot_ti_dhdl(self, estimaters, units):
         ti, mbar = estimaters
-        ax = plot_ti_dhdl(ti, units='kT')
-        assert isinstance(ax, matplotlib.axes.Axes)
-        plt.close(ax.figure)
-
-    def test_plot_ti_dhdl_kJ(self, estimaters):
-        ti, mbar = estimaters
-        ax = plot_ti_dhdl(ti, units='kJ/mol')
-        assert isinstance(ax, matplotlib.axes.Axes)
-        plt.close(ax.figure)
-
-    def test_plot_ti_dhdl_kcal(self, estimaters):
-        ti, mbar = estimaters
-        ax = plot_ti_dhdl(ti, units='kcal/mol')
+        ax = plot_ti_dhdl(ti, units=units)
         assert isinstance(ax, matplotlib.axes.Axes)
         plt.close(ax.figure)
 
@@ -231,3 +221,9 @@ class Test_Units():
         ti, mbar = estimaters
         with pytest.raises(ValueError):
             fig = plot_ti_dhdl(ti, units='ddd')
+
+    @pytest.mark.parametrize('units', [None, 'kT', 'kJ/mol', 'kcal/mol'])
+    def test_plot_convergence(self, convergence, units):
+        ax = plot_convergence(convergence)
+        assert isinstance(ax, matplotlib.axes.Axes)
+        plt.close(ax.figure)

--- a/src/alchemlyb/visualisation/convergence.py
+++ b/src/alchemlyb/visualisation/convergence.py
@@ -5,37 +5,35 @@ import numpy as np
 
 from ..postprocessors.units import get_unit_converter
 
-def plot_convergence(*data, units='kT', final_error=None, ax=None):
+def plot_convergence(dataframe, units=None, final_error=None, ax=None):
     """Plot the forward and backward convergence.
 
     The input could be the result from
-    :func:`~alchemlyb.convergence.forward_backward_convergence` or it could
-    be given explicitly as `forward`, `forward_error`, `backward`,
-    `backward_error`.
+    :func:`~alchemlyb.convergence.forward_backward_convergence` or
+    :func:`~alchemlyb.convergence.fwdrev_cumavg_Rc`. The input should be a
+    :class:`pandas.DataFrame` which has column `Forward`, `Backward` and
+    :attr:`pandas.DataFrame.attrs` should compile with :ref:`note-on-units`.
+    The errorbar will be plotted if column `Forward_Error` and `Backward_Error`
+    is present.
 
-    `forward`: A list of free energy estimate from the first X% of data,
-    where `forward_error` is the corresponding error.
+    `Forward`: A column of free energy estimate from the first X% of data,
+    where optional `Forward_Error` column is the corresponding error.
     
-    `backward`: A list of free energy estimate from the last X% of data.,
-    where `backward_error` is the corresponding error.
-
-    These four array_like objects should have the same
-    shape and can be used as input for the
-    :func:`matplotlib.pyplot.errorbar`.
+    `Backward`: A column of free energy estimate from the last X% of data.,
+    where optional `Backward_Error` column is the corresponding error.
 
    `final_error` is the error of the final value and is shown as the error band around the 
    final value. It can be provided in case an estimate is available that is more appropriate
-   than the default, which is the error of the last value in `backward`.
+   than the default, which is the error of the last value in `Backward`.
 
     Parameters
     ----------
-    data : Dataframe or 4 array_like objects
-        Output Dataframe from
-        :func:`~alchemlyb.convergence.forward_backward_convergence`.
-        Or given explicitly as `forward`, `forward_error`, `backward`,
-        `backward_error` see :ref:`plot_convergence <plot_convergence>`.
+    dataframe : Dataframe
+        Output Dataframe has column `Forward`, `Backward` or optionally
+        `Forward_Error`, `Backward_Error` see :ref:`plot_convergence <plot_convergence>`.
     units : str
-        The unit of the estimate. See `Note` for a detailed explanation. Default: "kT"
+        The unit of the estimate. The default is `None`, which is to use the
+        unit in the input. Setting this will change the output unit.
     final_error : float
         The error of the final value in ``units``. If not given, takes the last
         error in `backward_error`.
@@ -53,39 +51,30 @@ def plot_convergence(*data, units='kT', final_error=None, ax=None):
     The code is taken and modified from
     `Alchemical Analysis <https://github.com/MobleyLab/alchemical-analysis>`_.
 
-    If `data` is a :class:pandas.Dataframe` produced by
-    :func:`~alchemlyb.convergence.forward_backward_convergence`,
-    the unit will be adjusted according to the units
-    variable. Otherwise, the units variable is for labelling only, 
-    and changing it doesn't change the unit of the underlying variable.
-
 
     .. versionchanged:: 1.0.0
-        Keyword arg final_error for plotting a horizontal error bar
+        Keyword arg final_error for plotting a horizontal error bar.
+        The array input has been deprecated.
+        The units default to `None` which uses the units in the input.
 
     .. versionchanged:: 0.6.0
         data now takes in dataframe
 
     .. versionadded:: 0.4.0
     """
-    if len(data) == 1 and isinstance(data[0], pd.DataFrame):
-        dataframe = get_unit_converter(units)(data[0])
-        forward = dataframe['Forward'].to_numpy()
-        if 'Forward_Error' in dataframe:
-            forward_error = dataframe['Forward_Error'].to_numpy()
-        else:
-            forward_error = np.zeros(len(forward))
-        backward = dataframe['Backward'].to_numpy()
-        if 'Backward_Error' in dataframe:
-            backward_error = dataframe['Backward_Error'].to_numpy()
-        else:
-            backward_error = np.zeros(len(backward))
+    if units is not None:
+        dataframe = get_unit_converter(units)(dataframe)
+    forward = dataframe['Forward'].to_numpy()
+    if 'Forward_Error' in dataframe:
+        forward_error = dataframe['Forward_Error'].to_numpy()
     else:
-        try:
-            forward, forward_error, backward, backward_error = data
-        except ValueError: # pragma: no cover
-            raise ValueError('Ensure all four of forward, forward_error, '
-                             'backward, backward_error are supplied.')
+        forward_error = np.zeros(len(forward))
+    backward = dataframe['Backward'].to_numpy()
+    if 'Backward_Error' in dataframe:
+        backward_error = dataframe['Backward_Error'].to_numpy()
+    else:
+        backward_error = np.zeros(len(backward))
+
 
     if ax is None: # pragma: no cover
         fig, ax = plt.subplots(figsize=(8, 6))

--- a/src/alchemlyb/visualisation/dF_state.py
+++ b/src/alchemlyb/visualisation/dF_state.py
@@ -15,7 +15,7 @@ import numpy as np
 from ..estimators import TI, BAR, MBAR
 from ..postprocessors.units import get_unit_converter
 
-def plot_dF_state(estimators, labels=None, colors=None, units='kT',
+def plot_dF_state(estimators, labels=None, colors=None, units=None,
                   orientation='portrait', nb=10):
     '''Plot the dhdl of TI.
 
@@ -31,7 +31,8 @@ def plot_dF_state(estimators, labels=None, colors=None, units='kT',
     colors : List
         list of colors for plotting different estimators.
     units : str
-        The unit of the estimate. It will be used to change the underlying data to match the desired units. Default: "kT"
+        The unit of the estimate. The default is `None`, which is to use the
+        unit in the input. Setting this will change the output unit.
     orientation : string
         The orientation of the figure. Can be `portrait` or `landscape`
     nb : int
@@ -47,6 +48,9 @@ def plot_dF_state(estimators, labels=None, colors=None, units='kT',
     The code is taken and modified from
     `Alchemical Analysis <https://github.com/MobleyLab/alchemical-analysis>`_.
 
+
+    .. versionchanged:: 1.0.0
+        If no units is given, the `units` in the input will be used.
 
     .. versionchanged:: 0.5.0
         The `units` will be used to change the underlying data instead of only
@@ -66,6 +70,10 @@ def plot_dF_state(estimators, labels=None, colors=None, units='kT',
             formatted_data.append(dhdl)
         except TypeError:
             formatted_data.append([dhdl, ])
+
+    if units is None:
+        units = formatted_data[0][0].delta_f_.attrs['energy_unit']
+
     estimators = formatted_data
 
     # Get the dF

--- a/src/alchemlyb/visualisation/ti_dhdl.py
+++ b/src/alchemlyb/visualisation/ti_dhdl.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from ..postprocessors.units import get_unit_converter
 
-def plot_ti_dhdl(dhdl_data, labels=None, colors=None, units='kT',
+def plot_ti_dhdl(dhdl_data, labels=None, colors=None, units=None,
                  ax=None):
     '''Plot the dhdl of TI.
 
@@ -30,7 +30,8 @@ def plot_ti_dhdl(dhdl_data, labels=None, colors=None, units='kT',
         list of colors for plotting all the alchemical transformations.
         Default: ['r', 'g', '#7F38EC', '#9F000F', 'b', 'y']
     units : str
-        The unit of the estimate. It will be used to change the underlying data to match the desired units. Default: "kT"
+        The unit of the estimate. The default is `None`, which is to use the
+        unit in the input. Setting this will change the output unit.
     ax : matplotlib.axes.Axes
         Matplotlib axes object where the plot will be drawn on. If ``ax=None``,
         a new axes will be generated.
@@ -45,6 +46,9 @@ def plot_ti_dhdl(dhdl_data, labels=None, colors=None, units='kT',
     The code is taken and modified from
     `Alchemical Analysis <https://github.com/MobleyLab/alchemical-analysis>`_.
 
+
+    .. versionchanged:: 1.0.0
+        If no units is given, the `units` in the input will be used.
 
     .. versionchanged:: 0.5.0
         The `units` will be used to change the underlying data instead of only
@@ -64,6 +68,9 @@ def plot_ti_dhdl(dhdl_data, labels=None, colors=None, units='kT',
             dhdl_list.extend(dhdl.separate_dhdl())
 
     # Convert unit
+    if units is None:
+        units = dhdl_list[0].attrs['energy_unit']
+
     new_unit = []
     convert = get_unit_converter(units)
     for dhdl in dhdl_list:


### PR DESCRIPTION
Fix #247
Default the unit in `plot_dF_state` , `plot_convergence` and `plot_ti_dhdl` to None.
Remove the array input in `plot_convergence`.

I have fixed the issue here @DrDomenicoMarson