### PR TITLE
Raise Exception when no file has been matched in ABFE workflow

### DIFF
--- a/src/alchemlyb/tests/test_workflow_ABFE.py
+++ b/src/alchemlyb/tests/test_workflow_ABFE.py
@@ -33,6 +33,17 @@ def workflow(tmp_path_factory):
     return workflow
 
 
+class TestInit:
+    def test_nofilematch(self):
+        with pytest.raises(ValueError, match="No file has been matched to"):
+            ABFE(
+                dir="./",
+                prefix="dhdl",
+                suffix="xvg",
+                T=310,
+            )
+
+
 class TestRun:
     def test_none(self, workflow):
         """Don't run anything"""

--- a/src/alchemlyb/workflows/abfe.py
+++ b/src/alchemlyb/workflows/abfe.py
@@ -90,7 +90,11 @@ class ABFE(WorkflowBase):
             f"{suffix} under directory {dir} produced by "
             f"{software}"
         )
-        self.file_list = glob(dir + "/**/" + prefix + "*" + suffix, recursive=True)
+        reg_exp = dir + "/**/" + prefix + "*" + suffix
+        self.file_list = glob(reg_exp, recursive=True)
+
+        if len(list(self.file_list)) == 0:
+            raise ValueError(f"No file has been matched to {reg_exp}.")
 
         self.logger.info(f"Found {len(self.file_list)} xvg files.")
         self.logger.info("Unsorted file list: \n %s", "\n".join(self.file_list))


### PR DESCRIPTION
Related to https://github.com/alchemistry/flamel/issues/24. I noticed that when no file has been matched by the directory, prefix and suffix, no useful error message is being displayed. This PR should fix this issue.