### PR TITLE
309 make pip test work in m1 mac

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,8 +21,8 @@ Fixes
   - Fix the dE method in u_nk2series to use the difference between two
     lambda columns instead of using the next lambda column or the previous
     column for the last window (issue #299, PR #300).
-  - Use Path.glob instead of glob.glob in ABFE workflow to get the files
-    (issue #309, PR #310).
+  - work around hanging tests on Mac M1 by using Path.glob instead of glob.glob
+    in ABFE workflow (issue #309, PR #310).
 
 
 12/12/2022 xiki-tempula, orbeckst

--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Fixes
   - Fix the dE method in u_nk2series to use the difference between two
     lambda columns instead of using the next lambda column or the previous
     column for the last window (issue #299, PR #300).
+  - Use Path.glob instead of glob.glob in ABFE workflow to get the files
+    (issue #309, PR #310).
 
 
 12/12/2022 xiki-tempula, orbeckst

--- a/src/alchemlyb/workflows/abfe.py
+++ b/src/alchemlyb/workflows/abfe.py
@@ -1,7 +1,7 @@
 import logging
 import os
-from glob import glob
 from os.path import join
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -81,8 +81,8 @@ class ABFE(WorkflowBase):
             f"{suffix} under directory {dir} produced by "
             f"{software}"
         )
-        reg_exp = dir + "/**/" + prefix + "*" + suffix
-        self.file_list = list(glob(reg_exp, recursive=True))
+        reg_exp = "**/" + prefix + "*" + suffix
+        self.file_list = list(Path(dir).glob(reg_exp, recursive=True))
 
         if len(self.file_list) == 0:
             raise ValueError(f"No file has been matched to {reg_exp}.")

--- a/src/alchemlyb/workflows/abfe.py
+++ b/src/alchemlyb/workflows/abfe.py
@@ -82,7 +82,7 @@ class ABFE(WorkflowBase):
             f"{software}"
         )
         reg_exp = "**/" + prefix + "*" + suffix
-        self.file_list = list(Path(dir).glob(reg_exp))
+        self.file_list = list(map(str, Path(dir).glob(reg_exp)))
 
         if len(self.file_list) == 0:
             raise ValueError(f"No file has been matched to {reg_exp}.")

--- a/src/alchemlyb/workflows/abfe.py
+++ b/src/alchemlyb/workflows/abfe.py
@@ -82,7 +82,7 @@ class ABFE(WorkflowBase):
             f"{software}"
         )
         reg_exp = "**/" + prefix + "*" + suffix
-        self.file_list = list(Path(dir).glob(reg_exp, recursive=True))
+        self.file_list = list(Path(dir).glob(reg_exp))
 
         if len(self.file_list) == 0:
             raise ValueError(f"No file has been matched to {reg_exp}.")


### PR DESCRIPTION
Ok, I got it to work now by changing `glob.glob` to `Path.glob`, these two should be the same but `Path.glob` works fine.
I tried 
pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple alchemlyb=="2.0.1"
and then
pytest --pyargs alchemlyb

Where all tests passed fine.