### PR TITLE
capitalize GROMACS in documentation code example

### DIFF
--- a/docs/workflows/alchemlyb.workflows.base.rst
+++ b/docs/workflows/alchemlyb.workflows.base.rst
@@ -7,7 +7,7 @@ basic API template for the workflow development.  The workflow should
 be able to run in an automatic fashion. ::
 
     >>> from alchemlyb.workflows.base import WorkflowBase
-    >>> workflow = WorkflowBase(units='kT', software='Gromacs', T=298,
+    >>> workflow = WorkflowBase(units='kT', software='GROMACS', T=298,
         out='./', *args, **kwargs)
     >>> workflow.run(*args, **kwargs)
 
@@ -15,7 +15,7 @@ Three main functions are provided such that the workflow could be run in a
 step-by-step fashion. ::
 
     >>> from alchemlyb.workflows.base import WorkflowBase
-    >>> workflow = WorkflowBase(units='kT', software='Gromacs', T=298,
+    >>> workflow = WorkflowBase(units='kT', software='GROMACS', T=298,
         out='./', *args, **kwargs)
     >>> workflow.read(*args, **kwargs)
     >>> workflow.preprocess(*args, **kwargs)


### PR DESCRIPTION
Gromacs, as written, returns an error: "NotImplementedError: Gromacs parser not found."