### PR TITLE
adopt SPEC 0 instead of NEP 29

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,14 @@ The rules for this file:
   * release numbers follow "Semantic Versioning" https://semver.org
 
 ------------------------------------------------------------------------------
+??/??/2024 orbeckst
+
+  * 2.3.1
+
+Changes:
+  - alchemlyb adopts SPEC 0 (replaces NEP 29)
+    https://scientific-python.org/specs/spec-0000/
+
 
 21/05/2024 xiki-tempula
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,14 +52,12 @@ Development is done in the open on `GitHub`_.
 Software engineering best-practices are used throughout, including continuous integration testing via Github Actions, up-to-date documentation, and regular releases.
 
 .. Note::
-   With release 0.5.0, the alchemlyb project adopted `NEP 29`_ to determine which versions of Python and NumPy_ will be supported.
-   When we release a new major or minor version, alchemlyb will support *at least all minor versions of Python introduced and released in the prior 42 months from the release date with a minimum of 2 minor versions of Python*, and *all minor versions of NumPy released in the prior 24 months from the anticipated release date with a minimum of 3 minor versions of NumPy*.
-
-The pandas_ package (one of our other primary dependencies) also follows `NEP 29`_ so this support policy will make it easier to maintain **alchemlyb** in the future.
+   The alchemlyb project uses `SPEC 0`_ to determine which versions of  Python, NumPy_, and pandas_  will be supported.
+   When we release a new major or minor version, alchemlyb will support *at least all minor versions of Python introduced and released in the prior 3 years from the release date*, and *all minor versions of NumPy and pandas released in the prior 2 years from the anticipated release date*.
 
    
 .. _`GitHub`: https://github.com/alchemistry/alchemlyb
-.. _`NEP 29`: https://numpy.org/neps/nep-0029-deprecation_policy.html
+.. _`SPEC 0`: https://scientific-python.org/specs/spec-0000/
 .. _NumPy: https://numpy.org
 .. _pandas: https://pandas.pydata.org/
 


### PR DESCRIPTION
- fix #369
- once this is fixed, we can update the JOSS paper draft PR #328 to only mention SPEC 0