### PR TITLE
Minor changes to the paper

### DIFF
--- a/joss_paper/paper.bib
+++ b/joss_paper/paper.bib
@@ -12,7 +12,7 @@
 
 @article{Case2005uq,
 	author = {Case, David A and Cheatham, 3rd, Thomas E and Darden, Tom and Gohlke, Holger and Luo, Ray and Merz, Jr, Kenneth M and Onufriev, Alexey and Simmerling, Carlos and Wang, Bing and Woods, Robert J},
-	journal = {J Comput Chem},
+	journal = {Journal of Computational Chemistry},
 	number = {16},
 	pages = {1668-1688},
 	title = {The {Amber} biomolecular simulation programs},
@@ -25,7 +25,7 @@
 @article{chodera2007use,
   title={Use of the Weighted Histogram Analysis Method for the Analysis of Simulated and Parallel Tempering Simulations},
   author={J. D. Chodera and Swope, W. C. and Pitera, J. W. and Seok, C. and Dill, K. A.},
-  journal={J Chem Theory Comput},
+  journal={Journal of Chemical Theory and Computation},
   volume={3},
   number={1},
   pages={26-41},
@@ -48,7 +48,7 @@
 @article{deng2009computations,
   title={Computations of standard binding free energies with molecular dynamics simulations},
   author={Deng, Y. and Roux, B.},
-  journal={J Phys Chem B},
+  journal={The Journal of Physical Chemistry B},
   volume={113},
   number={8},
   pages={2234-2246},
@@ -95,7 +95,7 @@
 @article{klimovich2015guidelines,
   title={Guidelines for the analysis of free energy calculations},
   author={Klimovich, P. V. and Shirts, M. R. and Mobley, D. L.},
-  journal={J Comput Aided Mol Des},
+  journal={Journal of Computer-Aided Molecular Design},
   volume={29},
   number={5},
   pages={397-411},
@@ -108,12 +108,13 @@
   author={Merz, Jr, K. M. and Ringe, D. and Reynolds, C. H.},
   year={2010},
   publisher={Cambridge University Press},
+  doi = {10.48550/arXiv.1309.0238},
 }
 
 @article{paliwal2011benchmark,
   title={A Benchmark Test Set for Alchemical Free Energy Transformations and Its Use to Quantify Error in Common Free Energy Methods},
   author={Paliwal, H. and Shirts, M. R.},
-  journal={J Chem Theory Comput},
+  journal={Journal of Chemical Theory and Computation},
   volume={7},
   number={12},
   pages={4115-4134},
@@ -124,7 +125,7 @@
 @article{pham2011identifying,
   title={Identifying low variance pathways for free energy calculations of molecular transformations in solution phase},
   author={Pham, T. T. and Shirts, M. R.},
-  journal={J Chem Phys},
+  journal={The Journal of Chemical Physics},
   volume={135},
   number={3},
   pages={034114},
@@ -146,7 +147,7 @@
 @article{pohorille2010good,
   title={Good practices in free-energy calculations},
   author={Pohorille, A. and Jarzynski, C. and Chipot, C.},
-  journal={J Phys Chem B},
+  journal={The Journal of Physical Chemistry B},
   volume={114},
   number={32},
   pages={10235-10253},
@@ -168,7 +169,7 @@
 @article{shirts2008statistically,
   title={Statistically optimal analysis of samples from multiple equilibrium states},
   author={Shirts, M. R. and Chodera, J. D.},
-  journal={J Chem Phys},
+  journal={The Journal of Chemical Physics},
   volume={129},
   number={12},
   pages={124105},
@@ -179,7 +180,7 @@
 @article{yang2004free,
   title={Free energy simulations: use of reverse cumulative averaging to determine the equilibrated region and the time required for convergence},
   author={Yang, W. and Bitetti-Putzer, R. and Karplus, M.},
-  journal={J Chem Phys},
+  journal={The Journal of Chemical Physics},
   volume={120},
   number={6},
   pages={2618-2628},
@@ -254,6 +255,7 @@
   volume={12},
   pages={2825--2830},
   year={2011}
+  doi={10.5555/1953048.2078195}
 }
 
 @inproceedings{sklearn2013api,
@@ -267,6 +269,7 @@
   booktitle = {ECML PKDD Workshop: Languages for Data Mining and Machine Learning},
   year      = {2013},
   pages = {108--122},
+  doi = {10.48550/arXiv.1309.0238},
 }
 
 

--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -69,7 +69,7 @@ affiliations:
    index: 2
  - name: Datryllic LLC, Phoenix, Arizona, USA (present affiliation)
    index: 3
- - name: Open Free Energy, Open Molecular Software Foundation, Davis, 95616 California, United States
+ - name: Open Free Energy, Open Molecular Software Foundation, Davis, California, United States
    index: 4
  - name: Differentiated Therapeutics, San Diego, CA
    index: 5
@@ -91,7 +91,7 @@ affiliations:
    index: 13
  - name: PM Scientific Consulting, Basel, Switzerland
    index: 14
- - name: Stuttgart Center for Simulation Science (SC SimTech) & Institute for Computational Physics, University of Stuttgart, 70569 Stuttgart, Germany 
+ - name: Stuttgart Center for Simulation Science (SC SimTech) & Institute for Computational Physics, University of Stuttgart, Stuttgart, Germany 
    index: 15
  - name: University of Colorado Boulder, Boulder, Colorado, USA
    index: 16
@@ -105,7 +105,7 @@ bibliography: paper.bib
 
 # Summary
 
-*alchemlyb* is an open-source Python software package for the analysis of alchemical free energy calculations, an important method in computational chemistry and biology, most notably in the field of drug discovery.
+*alchemlyb* is an open-source Python software package for the analysis of alchemical free energy calculations, an important method in computational chemistry and biology, most notably in the field of drug discovery [@merz2010drug].
 Its functionality contains individual composable building blocks for all aspects of a full typical free energy analysis workflow, starting with the extraction of raw data from the output of diverse molecular simulation packages, moving on to data preprocessing tasks such as decorrelation of time series, using various estimators to derive free energy estimates from simulation samples, and finally providing quality analysis tools for data convergence checking and visualization.
 *alchemlyb* also contains high-level end-to-end workflows that combine multiple building blocks into a user-friendly analysis pipeline from the initial data input stage to the final results. This workflow functionality enhances accessibility by enabling researchers from diverse scientific backgrounds, and not solely computational chemistry specialists, to use *alchemlyb* effectively.
 
@@ -140,7 +140,7 @@ Notably, *alchemlyb*'s robust and user-friendly nature has led to its integratio
 
 # Background: Alchemical free energy calculations
 
-Free energy differences are fundamental to understand many different processes at the molecular scale, ranging from the binding of drug molecules to their receptor proteins or nucleic acids through the partitioning of molecules into different solvents or phases to the stability of crystals and biomolecules.
+Free energy differences are fundamental to understand many different processes at the molecular scale, ranging from the binding of drug molecules to their receptor proteins or nucleic acids through the partitioning of molecules into different solvents or phases to the stability of crystals and biomolecules [@deng2009computations].
 The calculation of such transfer free energies involves constructing two end states where a target molecule interacts with different environments.
 For example, in a solvation free energy calculation, in one state (the coupled state) the target molecule interacts with a solvent (in the case of hydration free energies, water), while in the other state (the decoupled state) the ligand has no intermolecular interactions, which mimics the transfer of a ligand from infinite dilution in the solvent to the gas phase.
 The solvation free energy is then obtained by calculating the free energy difference between these two end states, but it is crucial to ensure sufficient overlap in phase space between the coupled and decoupled states, a condition often challenging to achieve.
@@ -155,7 +155,7 @@ Estimators are then applied to these data to compute free energy differences bet
 # Implementation
 ## Core design principles
 
-*alchemlyb* is a Python library that seeks to make doing alchemical free energy calculations easier and less error prone. 
+*alchemlyb* is a Python library that seeks to make alchemical free energy calculations easier and less error prone. 
 It includes functionality for parsing data from file formats of widely used simulation packages, subsampling these data, and fitting these data with an estimator to obtain free energies. 
 Functions are simple in usage and pure in scope, and can be chained together to build customized analyses of data while estimators are implemented as classes that follow the tried-and-tested scikit-learn API [@sklearn2013api].
 General and robust workflows following best practices are also provided, which can be used as reference implementations and examples.
@@ -192,7 +192,7 @@ FEP category estimators (module `alchemlyb.estimators.FEP`) include Bennett Acce
 To evaluate the accuracy of the free energy estimate, *alchemlyb* offers a range of assessment tools.
 The error of the TI method is correlated with the average curvature [@pham2011identifying], while the error of FEP estimators depends on the overlap in sampled energy distributions [@pohorille2010good].
 *alchemlyb* creates visualizations of the smoothness of the integrand for TI estimators and the overlap matrix for FEP estimators, which can be qualitatively and quantitatively analyzed to determine the degree of overlap between simulated alchemical states, and suggest whether additional simulations should be run.
-For statistical validity, the accumulated samples should be collected from equilibrated simulations and *alchemlyb* contains tools for assessing (`alchemlyb.convergence`) and plotting (`alchemlyb.visualisation`) the convergence of the free energy estimate as a function of simulation time [@yang2004free] and means to compute the "fractional equilibration time" [@fan2020aa] to detect potentially un-equilibrated data.
+For statistical validity, the accumulated samples should be collected from equilibrated simulations and *alchemlyb* contains tools for assessing (`alchemlyb.convergence`) and plotting (`alchemlyb.visualisation`) the convergence of the free energy estimate as a function of simulation time [@yang2004free] and means to compute the "fractional equilibration time" [@fan2020aa] to detect potentially non-equilibrated data.
 
 *alchemlyb* offers all these tools as a library for users to customize each stage of the analysis (\autoref{fig:buildingblocks}).
 
@@ -211,7 +211,7 @@ It can directly estimate quantities such as solvation free energies and makes it
 
 # Acknowledgements
 
-Some work on alchemlyb was supported by grants from the  National
+Some work on *alchemlyb* was supported by grants from the  National
 Institutes of Health (Award No R01GM118772 to O.B., R35GM148236 to
 D.M., K08GM139031 to T.T.J.) and the National Science Foundation (award ACI-1443054 to O.B.). A.S. acknowledges funding by Deutsche Forschungsgemeinschaft (DFG, German Research Foundation) under Germany's Excellence Strategy - EXC 2075 – 390740016 and support by the Stuttgart Center for Simulation Science (SimTech).
 The sponsors were not involved in any aspects of the research or the writing of the manuscript.

--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -42,6 +42,7 @@ authors:
     orcid: 0000-0003-4030-9312
     affiliation: 11
   - name: Shuai Liu
+    orcid: 0000-0002-8632-633X
     affiliation: 12
   - name: Domenico Marson
     orcid: 0000-0003-1839-9868


### PR DESCRIPTION
Fix #386
> Shuai Liu is missing ORCid

@shuail 

> Affiliations: some of the have zip codes, some of them dont

All zip code removed

> line 23-25 could be better with a general citation

Add merz2010drug

> line 81-84 could be better with a general citation

Add deng2009computations

> line 111 - you could remove the word 'doing'

Removed

> line 182 - is it un-equilibrated or non-equilibrated?

non-equilibrated

> line 198 - formatting for 'alchemlyb' is not there

Formatted

> line 221 - citation, please check DOI

Added.

> line 257 - citation, please recheck DOI

This is a book and I cannot find a DOI

> line 271 - citation, please recheck DOI

Added

> line 293 - citation, please recheck DOI

Book, cannot find DOI

> some journal names are abbreviations, some are full, could you please make them consistent?

All full now.