### PR TITLE
make zenodo archive title identical to JOSS paper title

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,10 +3,11 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: alchemlyb
+title: 'alchemlyb: the simple alchemistry library'
 message: >-
   If you use this software, please cite it using the
-  preferred citation together with any other references.
+  preferred citation (JOSS DOI 10.21105/joss.06934) together
+  with any other references.
 type: software
 authors:
   - email: david@datryllic.com


### PR DESCRIPTION
- close #402
- use same title in CITATION.cff for paper and project (required for the JOSS paper publication #71)
- added DOI for preferred citation in note because that is the only hint that shows up on zenodo)