### PR TITLE
correct error in tutorial for plot_convergence()

### DIFF
--- a/docs/visualisation.rst
+++ b/docs/visualisation.rst
@@ -177,7 +177,8 @@ and the corresponding error. ::
     >>>     backward_error.append(estimate.d_delta_f_.iloc[0,-1])
 
     >>> from alchemlyb.visualisation import plot_convergence
-    >>> ax = plot_convergence(forward, forward_error, backward, backward_error)
+    >>> df = pd.DataFrame({'Forward':forward, 'Backward':backward, 'Forward_Error':forward_error, 'Backward_Error':backward_error})
+    >>> ax = plot_convergence(df)
     >>> ax.figure.savefig('dF_t.pdf')
 
 Will give a plot looks like this


### PR DESCRIPTION
The function plot_convergence() expects a pandas dataframe as the single argument in the current implementation, causing it to fail when passed 4 different lists as arguments instead. This edit corrects the tutorial to appropriately pass a single dataframe with the appropriate column names, resulting in code that successfully reproduces the example graph.  
  
This should resolve issue #421.