### PR TITLE
fix: remove stale slicing type ignore

### DIFF
--- a/src/alchemlyb/preprocessing/subsampling.py
+++ b/src/alchemlyb/preprocessing/subsampling.py
@@ -451,7 +451,7 @@ def slicing(
        The rows with NaN values are not dropped by default.
     """
     try:
-        df = df.loc[lower:upper:step]  # type: ignore[misc]
+        df = df.loc[lower:upper:step]
     except KeyError:
         raise KeyError("DataFrame rows must be sorted by time, increasing.")
 


### PR DESCRIPTION
## Summary
- remove the unused `type: ignore[misc]` suppression from `slicing()`
- allow the mypy unused-ignore check to pass for the reported line

## Tests
- `.venv/bin/mypy src/alchemlyb/preprocessing/subsampling.py --ignore-missing-imports --disable-error-code no-any-return`
- `.venv/bin/python -m compileall -q src/alchemlyb/preprocessing/subsampling.py`
- `git diff --check`

Closes #460